### PR TITLE
Fixed teachSkill missing an argument on quest 4647

### DIFF
--- a/scripts/quest/4647.js
+++ b/scripts/quest/4647.js
@@ -41,7 +41,7 @@ function end(mode, type, selection) {
 		if (status == 0) {
 			if(qm.haveItem(5460000)) {
 				qm.sendOk("You got the Pet Snack! Thanks! You can use these to feed multiple pets at once!");
-				qm.teachSkill(0008, 1, 1);
+				qm.teachSkill(0008, 1, 1, -1);
 				qm.gainItem(5460000, -1, false);
 				qm.completeQuest();
 				qm.dispose();


### PR DESCRIPTION
The following error was thrown when trying to complete the quest.
`javax.script.ScriptException: sun.org.mozilla.javascript.internal.EvaluatorException: Can't find method scripting.AbstractPlayerInteraction.teachSkill(number,number,number). (<Unknown source>#44) in <Unknown source> at line number 44`
Adding the missing argument fixes the issue and allows the quest to complete correctly.