### PR TITLE
Updated forceChangeMap for better GM Warpto

### DIFF
--- a/src/client/MapleCharacter.java
+++ b/src/client/MapleCharacter.java
@@ -1359,7 +1359,7 @@ public class MapleCharacter extends AbstractMapleCharacterObject {
             mapEim.registerPlayer(this);
         }
         
-        MapleMap to = getWarpMap(target.getId());
+        MapleMap to = target; // warps directly to the target intead of the target's map id, this allows GMs to patrol players inside instances.
         changeMapInternal(to, pto.getPosition(), MaplePacketCreator.getWarpToMap(to, pto.getId(), this));
         canWarpMap = false;
         


### PR DESCRIPTION
* Asked by Lost and solution suggested by Ronan in discord group.
* Using "target;" instead of "getWarpMap(target.getId());" to warp directly to the target intead of the target's map id.
* This allows GMs to patrol players inside instances.