### PR TITLE
Fix Hero's Will master level 10

### DIFF
--- a/wz/Item.wz/Consume/0228.img.xml
+++ b/wz/Item.wz/Consume/0228.img.xml
@@ -51,7 +51,7 @@
       <int name="only" value="1"/>
       <int name="tradeBlock" value="1"/>
       <int name="success" value="100"/>
-      <int name="masterLevel" value="10"/>
+      <int name="masterLevel" value="5"/>
       <imgdir name="skill">
         <int name="0" value="1121011"/>
         <int name="1" value="1221012"/>


### PR DESCRIPTION
Alternatively, could add a check so that the master level is not raised higher than possible by an item, instead of changing the WZ value.