### PR TITLE
Make PlayerStorage.getAllCharacters() return a copy

### DIFF
--- a/src/net/server/PlayerStorage.java
+++ b/src/net/server/PlayerStorage.java
@@ -84,7 +84,7 @@ public class PlayerStorage {
     public Collection<MapleCharacter> getAllCharacters() {
         rlock.lock();
         try {
-            return storage.values();
+            return new ArrayList<>(storage.values());
         } finally {
             rlock.unlock();
         }

--- a/src/net/server/world/World.java
+++ b/src/net/server/world/World.java
@@ -293,7 +293,7 @@ public class World {
     }
 
     public void setExpRate(int exp) {
-        List<MapleCharacter> list = new LinkedList<>(getPlayerStorage().getAllCharacters());
+        Collection<MapleCharacter> list = getPlayerStorage().getAllCharacters();
         
         for(MapleCharacter chr : list) {
             if(!chr.isLoggedin()) continue;
@@ -311,7 +311,7 @@ public class World {
     }
 
     public void setDropRate(int drop) {
-        List<MapleCharacter> list = new LinkedList<>(getPlayerStorage().getAllCharacters());
+        Collection<MapleCharacter> list = getPlayerStorage().getAllCharacters();
         
         for(MapleCharacter chr : list) {
             if(!chr.isLoggedin()) continue;
@@ -337,8 +337,8 @@ public class World {
     }
 
     public void setMesoRate(int meso) {
-        List<MapleCharacter> list = new LinkedList<>(getPlayerStorage().getAllCharacters());
-        
+        Collection<MapleCharacter> list = getPlayerStorage().getAllCharacters();
+
         for(MapleCharacter chr : list) {
             if(!chr.isLoggedin()) continue;
             chr.revertWorldRates();

--- a/src/server/life/MapleMonsterInformationProvider.java
+++ b/src/server/life/MapleMonsterInformationProvider.java
@@ -343,6 +343,7 @@ public class MapleMonsterInformationProvider {
                 extraMultiEquipDrops.clear();
                 dropsChancePool.clear();
 		globaldrops.clear();
+		continentdrops.clear();
 		retrieveGlobal();
 	}
 }


### PR DESCRIPTION
You can get ConcurrentModificationException if a player is removed from PlayerStorage while another thread is looping through PlayerStorage.getAllCharacters()
```java
java.util.ConcurrentModificationException
	at java.util.LinkedHashMap$LinkedHashIterator.nextEntry(LinkedHashMap.java:394)
	at java.util.LinkedHashMap$ValueIterator.next(LinkedHashMap.java:409)
	at net.server.worker.CharacterAutosaverWorker.run(CharacterAutosaverWorker.java:37)
	at server.TimerManager$LoggingSaveRunnable.run(TimerManager.java:148)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:473)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:304)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:178)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1152)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:622)
	at java.lang.Thread.run(Thread.java:748)
```