### PR TITLE
Fix MTS buyback (player need alive to use right?)

### DIFF
--- a/src/net/server/channel/handlers/EnterMTSHandler.java
+++ b/src/net/server/channel/handlers/EnterMTSHandler.java
@@ -49,7 +49,7 @@ public final class EnterMTSHandler extends AbstractMaplePacketHandler {
     public final void handlePacket(SeekableLittleEndianAccessor slea, MapleClient c) {
         MapleCharacter chr = c.getPlayer();
         
-        if(!chr.isAlive() && ServerConstants.USE_BUYBACK_SYSTEM) {
+        if(chr.isAlive() && ServerConstants.USE_BUYBACK_SYSTEM) {
             BuybackProcessor.processBuyback(c);
             c.announce(MaplePacketCreator.enableActions());
         } else {


### PR DESCRIPTION
Looks like there's an error in the MTS buy-back functionality. Player shouldn't have to be dead to use this right?