### PR TITLE
Fix client crash when entering portal from 800030000

### DIFF
--- a/wz/Map.wz/Map/Map8/800030000.img.xml
+++ b/wz/Map.wz/Map/Map8/800030000.img.xml
@@ -8036,7 +8036,7 @@
       <int name="pt" value="2"/>
       <int name="x" value="1818"/>
       <int name="y" value="-1259"/>
-      <int name="tm" value="801030000"/>
+      <int name="tm" value="801010000"/>
       <string name="tn" value="west00"/>
     </imgdir>
   </imgdir>


### PR DESCRIPTION
I'm not sure, but this fixes the crash I encountered when on my way from JP entry(800000000 - Zipangu - Mushroom Shrine) to 801000000 - Zipangu - Showa Town