### PR TITLE
Fix Java 8 support

### DIFF
--- a/configuration.ini
+++ b/configuration.ini
@@ -2,5 +2,4 @@ HOST=127.0.0.1
 URL=jdbc:mysql://localhost:3306/heavenms
 DB_USER=root
 DB_PASS=
-JAVA8=FALSE
 SHUTDOWNHOOK=true

--- a/src/constants/ServerConstants.java
+++ b/src/constants/ServerConstants.java
@@ -51,10 +51,8 @@ public class ServerConstants {
     public static boolean LOCALSERVER;
 
     //Other Configuration
-    public static boolean JAVA_8;
+    public static final boolean JAVA_8 = getJavaVersion() >= 8;
     public static boolean SHUTDOWNHOOK;
-    // JAVA_8: every static function in AbstractPlayerInteraction are to be made non-static, and code comment sections uncommented after enabling this functionality.
-    
     
     //Server Flags
     public static final boolean USE_CUSTOM_KEYSET = true;           //Enables auto-setup of the HeavenMS's custom keybindings when creating characters.
@@ -318,8 +316,7 @@ public class ServerConstants {
             ServerConstants.DB_USER = p.getProperty("DB_USER");
             ServerConstants.DB_PASS = p.getProperty("DB_PASS");
 
-            //java8 And Shutdownhook
-            ServerConstants.JAVA_8 = p.getProperty("JAVA8").equalsIgnoreCase("TRUE");
+            // shutdownhook
             ServerConstants.SHUTDOWNHOOK = p.getProperty("SHUTDOWNHOOK").equalsIgnoreCase("true");
 
         } catch (Exception e) {
@@ -327,5 +324,26 @@ public class ServerConstants {
             System.out.println("Failed to load configuration.ini.");
             System.exit(0);
         }
+    }
+    // https://github.com/openstreetmap/josm/blob/a3a6e8a6b657cf4c5b4c64ea14d6e87be6280d65/src/org/openstreetmap/josm/tools/Utils.java#L1566-L1585
+    /**
+     * Returns the Java version as an int value.
+     * @return the Java version as an int value (8, 9, etc.)
+     * @since 12130
+     */
+    public static int getJavaVersion() {
+        String version = System.getProperty("java.version");
+        if (version.startsWith("1.")) {
+            version = version.substring(2);
+        }
+        // Allow these formats:
+        // 1.8.0_72-ea
+        // 9-ea
+        // 9
+        // 9.0.1
+        int dotPos = version.indexOf('.');
+        int dashPos = version.indexOf('-');
+        return Integer.parseInt(version.substring(0,
+                dotPos > -1 ? dotPos : dashPos > -1 ? dashPos : 1));
     }
 }

--- a/src/scripting/AbstractPlayerInteraction.java
+++ b/src/scripting/AbstractPlayerInteraction.java
@@ -95,7 +95,7 @@ public class AbstractPlayerInteraction {
                 return c.getPlayer().getMap();
         }
         
-        public static int getHourOfDay() {
+        public int getHourOfDay() {
                 return Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
         }
         
@@ -103,7 +103,7 @@ public class AbstractPlayerInteraction {
             return getMarketPortalId(getWarpMap(mapId));
         }
         
-        private static int getMarketPortalId(MapleMap map) {
+        private int getMarketPortalId(MapleMap map) {
             return (map.findMarketPortal() != null) ? map.findMarketPortal().getId() : map.getRandomPlayerSpawnpoint().getId();
         }
         
@@ -235,7 +235,7 @@ public class AbstractPlayerInteraction {
                 return canHoldAllAfterRemoving(Collections.singletonList(itemid), Collections.singletonList(quantity), Collections.singletonList(removeItemid), Collections.singletonList(removeQuantity));
         }
         
-        private static List<Integer> convertToIntegerArray(List<Double> list) {
+        private List<Integer> convertToIntegerArray(List<Double> list) {
                 List<Integer> intList = new LinkedList<>();
                 for(Double d: list) {
                         intList.add(d.intValue());
@@ -269,7 +269,7 @@ public class AbstractPlayerInteraction {
             return MapleInventory.checkSpots(c.getPlayer(), addedItems, false);
         }
         
-        private static List<Pair<Item, MapleInventoryType>> prepareProofInventoryItems(List<Pair<Integer, Integer>> items) {
+        private List<Pair<Item, MapleInventoryType>> prepareProofInventoryItems(List<Pair<Integer, Integer>> items) {
             List<Pair<Item, MapleInventoryType>> addedItems = new LinkedList<>();
             for(Pair<Integer, Integer> p : items) {
                 Item it = new Item(p.getLeft(), (short) 0, p.getRight().shortValue());
@@ -279,7 +279,7 @@ public class AbstractPlayerInteraction {
             return addedItems;
         }
         
-        private static List<List<Pair<Integer, Integer>>> prepareInventoryItemList(List<Integer> itemids, List<Integer> quantity) {
+        private List<List<Pair<Integer, Integer>>> prepareInventoryItemList(List<Integer> itemids, List<Integer> quantity) {
             int size = Math.min(itemids.size(), quantity.size());
             
             List<List<Pair<Integer, Integer>>> invList = new ArrayList<>(6);
@@ -947,7 +947,7 @@ public class AbstractPlayerInteraction {
 		c.announce(MaplePacketCreator.modifyInventory(false, Collections.singletonList(new ModifyInventory(0, newItem))));
 	}
         
-        public static void spawnNpc(int npcId, Point pos, MapleMap map) {
+        public void spawnNpc(int npcId, Point pos, MapleMap map) {
                 MapleNPC npc = MapleLifeFactory.getNPC(npcId);
                 if (npc != null) {
                         npc.setPosition(pos);
@@ -966,11 +966,11 @@ public class AbstractPlayerInteraction {
 		getPlayer().getMap().spawnMonster(monster);
 	}
         
-	public static MapleMonster getMonsterLifeFactory(int mid) {
+	public MapleMonster getMonsterLifeFactory(int mid) {
 		return MapleLifeFactory.getMonster(mid);
 	}
         
-        public static MobSkill getMobSkill(int skill, int level) {
+        public MobSkill getMobSkill(int skill, int level) {
 		return MobSkillFactory.getMobSkill(skill, level);
 	}
 
@@ -1153,7 +1153,7 @@ public class AbstractPlayerInteraction {
                 }
         }
         
-        public static String getFirstJobStatRequirement(int jobType) {
+        public String getFirstJobStatRequirement(int jobType) {
                 switch(jobType) {
                     case 1:
                         return "STR " + 35;

--- a/src/scripting/event/EventManager.java
+++ b/src/scripting/event/EventManager.java
@@ -21,6 +21,8 @@
 */
 package scripting.event;
 
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
+import jdk.nashorn.api.scripting.ScriptUtils;
 import tools.exceptions.EventInstanceInProgressException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -165,14 +167,14 @@ public class EventManager {
         startLock = startLock.dispose();
     }
     
-    private static List<Integer> convertToIntegerArray(List<Double> list) {
+    private List<Integer> convertToIntegerArray(List<Double> list) {
         List<Integer> intList = new ArrayList<>();
         for(Double d: list) intList.add(d.intValue());
 
         return intList;
     }
     
-    public static long getLobbyDelay() {
+    public long getLobbyDelay() {
         return ServerConstants.EVENT_LOBBY_DELAY;
     }
     
@@ -181,7 +183,6 @@ public class EventManager {
             if (!ServerConstants.JAVA_8) {
                 return convertToIntegerArray((List<Double>)iv.invokeFunction("setLobbyRange", (Object) null));
             } else {  // java 8 support here thanks to MedicOP
-                /*
                 ScriptObjectMirror object = (ScriptObjectMirror) iv.invokeFunction("setLobbyRange", (Object) null);
                 int[] to = object.to(int[].class);
                 List<Integer> list = new ArrayList<>();
@@ -189,9 +190,7 @@ public class EventManager {
                     list.add(i);
                 }
                 return list;
-                */
-                
-                throw new NoSuchMethodException();
+
             }
         } catch (ScriptException | NoSuchMethodException ex) { // they didn't define a lobby range
             List<Integer> defaultRange = new ArrayList<>();
@@ -750,13 +749,12 @@ public class EventManager {
             if(p != null) {
                 List<MaplePartyCharacter> lmpc;
                 
-                /*if(ServerConstants.JAVA_8) {
+                if(ServerConstants.JAVA_8) {
                     lmpc = new ArrayList<>(((Map<String, MaplePartyCharacter>)(ScriptUtils.convert(p, Map.class))).values());
                 } else {
                     lmpc = new ArrayList<>((List<MaplePartyCharacter>) p);
-                }*/
-                
-                lmpc = new ArrayList<>((List<MaplePartyCharacter>) p);
+                }
+
                 party.setEligibleMembers(lmpc);
                 return lmpc;
             }

--- a/src/scripting/npc/NPCConversationManager.java
+++ b/src/scripting/npc/NPCConversationManager.java
@@ -97,9 +97,9 @@ public class NPCConversationManager extends AbstractPlayerInteraction {
         private boolean itemScript;
         private List<MaplePartyCharacter> otherParty;
         
-        private static Map<Integer, String> npcDefaultTalks = new HashMap<>();
+        private Map<Integer, String> npcDefaultTalks = new HashMap<>();
         
-        private static String getDefaultTalk(int npcid) {
+        private String getDefaultTalk(int npcid) {
             String talk = npcDefaultTalks.get(npcid);
             if (talk == null) {
                 talk = MapleLifeFactory.getNPCDefaultTalk(npcid);

--- a/src/scripting/reactor/ReactorActionManager.java
+++ b/src/scripting/reactor/ReactorActionManager.java
@@ -186,7 +186,7 @@ public class ReactorActionManager extends AbstractPlayerInteraction {
         return ReactorScriptManager.getInstance().getDrops(reactor.getId());
     }
     
-    private static List<ReactorDropEntry> generateDropList(List<ReactorDropEntry> drops, int dropRate, boolean meso, int mesoChance, int minItems) {
+    private List<ReactorDropEntry> generateDropList(List<ReactorDropEntry> drops, int dropRate, boolean meso, int mesoChance, int minItems) {
         MapleItemInformationProvider ii = MapleItemInformationProvider.getInstance();
         
         List<ReactorDropEntry> items = new ArrayList<>();


### PR DESCRIPTION
Support Java 7 has been dropped since April *2015*, leaving installations of JDK7 vulnerable. We should make serious efforts to migrate.

This PR improves Java 8 support:
* Remove static tags from `AbstractPlayerInteraction` and `NPCConversationManager`.
* Remove `JAVA_8` configuration option en lieu of runtime detection.
* Uncomment instances I could find of JAVA_8 comments.