### PR TITLE
Script engine refactor preparation

### DIFF
--- a/src/client/MapleClient.java
+++ b/src/client/MapleClient.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.Lock;
 
+import jdk.nashorn.api.scripting.NashornScriptEngine;
 import tools.*;
 
 import javax.script.ScriptEngine;
@@ -106,7 +107,7 @@ public class MapleClient {
 	private long lastPong;
 	private int gmlevel;
 	private Set<String> macs = new HashSet<>();
-	private Map<String, ScriptEngine> engines = new HashMap<>();
+	private Map<String, NashornScriptEngine> engines = new HashMap<>();
 	private byte characterSlots = 3;
 	private byte loginattempt = 0;
 	private String pin = "";
@@ -1162,11 +1163,11 @@ public class MapleClient {
 		gmlevel = level;
 	}
 
-	public void setScriptEngine(String name, ScriptEngine e) {
+	public void setScriptEngine(String name, NashornScriptEngine e) {
                 engines.put(name, e);
 	}
 
-	public ScriptEngine getScriptEngine(String name) {
+	public NashornScriptEngine getScriptEngine(String name) {
 		return engines.get(name);
 	}
 

--- a/src/scripting/event/EventScriptManager.java
+++ b/src/scripting/event/EventScriptManager.java
@@ -54,7 +54,7 @@ public class EventScriptManager extends AbstractScriptManager {
         super();
         for (String script : scripts) {
             if (!script.equals("")) {
-                Invocable iv = getInvocable("event/" + script + ".js", null);
+                Invocable iv = getScriptEngine("event/" + script + ".js", null);
                 events.put(script, new EventEntry(iv, new EventManager(cserv, iv, script)));
             }
         }
@@ -88,7 +88,7 @@ public class EventScriptManager extends AbstractScriptManager {
         Channel cserv = events.values().iterator().next().em.getChannelServer();
         for (Entry<String, EventEntry> entry : events.entrySet()) {
             String script = entry.getKey();
-            Invocable iv = getInvocable("event/" + script + ".js", null);
+            Invocable iv = getScriptEngine("event/" + script + ".js", null);
             events.put(script, new EventEntry(iv, new EventManager(cserv, iv, script)));
         }
     }

--- a/src/scripting/event/EventScriptManager.java
+++ b/src/scripting/event/EventScriptManager.java
@@ -54,7 +54,7 @@ public class EventScriptManager extends AbstractScriptManager {
         super();
         for (String script : scripts) {
             if (!script.equals("")) {
-                Invocable iv = getScriptEngine("event/" + script + ".js", null);
+                Invocable iv = getScriptEngine("event/" + script + ".js");
                 events.put(script, new EventEntry(iv, new EventManager(cserv, iv, script)));
             }
         }
@@ -88,7 +88,7 @@ public class EventScriptManager extends AbstractScriptManager {
         Channel cserv = events.values().iterator().next().em.getChannelServer();
         for (Entry<String, EventEntry> entry : events.entrySet()) {
             String script = entry.getKey();
-            Invocable iv = getScriptEngine("event/" + script + ".js", null);
+            Invocable iv = getScriptEngine("event/" + script + ".js");
             events.put(script, new EventEntry(iv, new EventManager(cserv, iv, script)));
         }
     }

--- a/src/scripting/npc/NPCScriptManager.java
+++ b/src/scripting/npc/NPCScriptManager.java
@@ -105,11 +105,7 @@ public class NPCScriptManager extends AbstractScriptManager {
             try {
                 iv.invokeFunction("start", chrs);
             } catch (final NoSuchMethodException nsme) {
-                try {
-                    iv.invokeFunction("start", chrs);
-                } catch (final NoSuchMethodException nsma) {
-                    nsma.printStackTrace();
-                }
+                nsme.printStackTrace();
             }
 
         } catch (final UndeclaredThrowableException ute) {

--- a/src/scripting/npc/NPCScriptManager.java
+++ b/src/scripting/npc/NPCScriptManager.java
@@ -30,7 +30,10 @@ import java.util.List;
 import java.util.Map;
 
 import javax.script.Invocable;
+import javax.script.ScriptEngine;
 import javax.script.ScriptException;
+
+import jdk.nashorn.api.scripting.NashornScriptEngine;
 import net.server.world.MaplePartyCharacter;
 
 import scripting.AbstractScriptManager;
@@ -56,7 +59,7 @@ public class NPCScriptManager extends AbstractScriptManager {
     public boolean isNpcScriptAvailable(MapleClient c, String fileName) {
         Invocable iv = null;
         if (fileName != null) {
-            iv = getInvocable("npc/" + fileName + ".js", c);
+            iv = getScriptEngine("npc/" + fileName + ".js", c);
         }
 
         return iv != null;
@@ -90,15 +93,14 @@ public class NPCScriptManager extends AbstractScriptManager {
                 return;
             }
             cms.put(c, cm);
-            Invocable iv = null;
-            iv = getInvocable("npc/" + filename + ".js", c);
+            NashornScriptEngine iv = getScriptEngine("npc/" + filename + ".js", c);
 
             if (iv == null) {
                 c.getPlayer().dropMessage(1, npc + "");
                 cm.dispose();
                 return;
             }
-            engine.put("cm", cm);
+            iv.put("cm", cm);
             scripts.put(c, iv);
             try {
                 iv.invokeFunction("start", chrs);
@@ -127,25 +129,25 @@ public class NPCScriptManager extends AbstractScriptManager {
             }
             if (c.canClickNPC()) {
                 cms.put(c, cm);
-                Invocable iv = null;
+                NashornScriptEngine iv = null;
                 if (!itemScript) {
                     if (fileName != null) {
-                        iv = getInvocable("npc/" + fileName + ".js", c);
+                        iv = getScriptEngine("npc/" + fileName + ".js", c);
                     }
                 } else {
                     if (fileName != null) {     // thanks MiLin for drafting NPC-based item scripts
-                        iv = getInvocable("item/" + fileName + ".js", c);
+                        iv = getScriptEngine("item/" + fileName + ".js", c);
                     }
                 }
                 if (iv == null) {
-                    iv = getInvocable("npc/" + npc + ".js", c);
+                    iv = getScriptEngine("npc/" + npc + ".js", c);
                     cm.resetItemScript();
                 }
                 if (iv == null) {
                     dispose(c);
                     return false;
                 }
-                engine.put(engineName, cm);
+                iv.put(engineName, cm);
                 scripts.put(c, iv);
                 c.setClickedNPC();
                 try {

--- a/src/scripting/quest/QuestScriptManager.java
+++ b/src/scripting/quest/QuestScriptManager.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import javax.script.Invocable;
 
+import jdk.nashorn.api.scripting.NashornScriptEngine;
 import scripting.AbstractScriptManager;
 import server.quest.MapleQuest;
 import tools.FilePrinter;
@@ -62,10 +63,10 @@ public class QuestScriptManager extends AbstractScriptManager {
                         }
                         if(c.canClickNPC()) {
                                 qms.put(c, qm);
-                                Invocable iv = getInvocable("quest/" + questid + ".js", c);
+							NashornScriptEngine iv = getScriptEngine("quest/" + questid + ".js", c);
                                 if (iv == null) {
                                         if(GameConstants.isMedalQuest(questid)) {   // start generic medal quest
-                                                iv = getInvocable("quest/medalQuest.js", c);
+                                                iv = getScriptEngine("quest/medalQuest.js", c);
                                         } else {
                                                 FilePrinter.printError(FilePrinter.QUEST_UNCODED, "START Quest " + questid + " is uncoded.");
                                         }
@@ -74,7 +75,7 @@ public class QuestScriptManager extends AbstractScriptManager {
                                         qm.dispose();
                                         return;
                                 }
-                                engine.put("qm", qm);
+                                iv.put("qm", qm);
                                 scripts.put(c, iv);
                                 c.setClickedNPC();
                                 iv.invokeFunction("start", (byte) 1, (byte) 0, 0);
@@ -117,17 +118,17 @@ public class QuestScriptManager extends AbstractScriptManager {
 			}
 			if(c.canClickNPC()){
 				qms.put(c, qm);
-				Invocable iv = getInvocable("quest/" + questid + ".js", c);
+				NashornScriptEngine iv = getScriptEngine("quest/" + questid + ".js", c);
 				if (iv == null) {
                                         if(GameConstants.isMedalQuest(questid)) {   // start generic medal quest
-                                                iv = getInvocable("quest/medalQuest.js", c);
+                                                iv = getScriptEngine("quest/medalQuest.js", c);
                                         } else {
                                                 FilePrinter.printError(FilePrinter.QUEST_UNCODED, "END Quest " + questid + " is uncoded.");
                                                 qm.dispose();
                                                 return;
                                         }
 				}
-				engine.put("qm", qm);
+				iv.put("qm", qm);
 				scripts.put(c, iv);
 				c.setClickedNPC();
 				iv.invokeFunction("end", (byte) 1, (byte) 0, 0);

--- a/src/scripting/quest/QuestScriptManager.java
+++ b/src/scripting/quest/QuestScriptManager.java
@@ -63,7 +63,7 @@ public class QuestScriptManager extends AbstractScriptManager {
                         }
                         if(c.canClickNPC()) {
                                 qms.put(c, qm);
-							NashornScriptEngine iv = getScriptEngine("quest/" + questid + ".js", c);
+                                NashornScriptEngine iv = getScriptEngine("quest/" + questid + ".js", c);
                                 if (iv == null) {
                                         if(GameConstants.isMedalQuest(questid)) {   // start generic medal quest
                                                 iv = getScriptEngine("quest/medalQuest.js", c);

--- a/src/scripting/reactor/ReactorScriptManager.java
+++ b/src/scripting/reactor/ReactorScriptManager.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import javax.script.Invocable;
 import javax.script.ScriptException;
+
+import jdk.nashorn.api.scripting.NashornScriptEngine;
 import scripting.AbstractScriptManager;
 import server.maps.MapleReactor;
 import server.maps.ReactorDropEntry;
@@ -52,11 +54,11 @@ public class ReactorScriptManager extends AbstractScriptManager {
     
     public void onHit(MapleClient c, MapleReactor reactor) {
         try {
-            Invocable iv = getInvocable("reactor/" + reactor.getId() + ".js", c);
+            NashornScriptEngine iv = getScriptEngine("reactor/" + reactor.getId() + ".js", c);
             if (iv == null) return;
             
             ReactorActionManager rm = new ReactorActionManager(c, reactor, iv);
-            engine.put("rm", rm);
+            iv.put("rm", rm);
             iv.invokeFunction("hit");
         } catch (final NoSuchMethodException e) {} //do nothing, hit is OPTIONAL
         
@@ -67,11 +69,11 @@ public class ReactorScriptManager extends AbstractScriptManager {
 
     public void act(MapleClient c, MapleReactor reactor) {
         try {
-            Invocable iv = getInvocable("reactor/" + reactor.getId() + ".js", c);
+            NashornScriptEngine iv = getScriptEngine("reactor/" + reactor.getId() + ".js", c);
             if (iv == null) return;
             
             ReactorActionManager rm = new ReactorActionManager(c, reactor, iv);
-            engine.put("rm", rm);
+            iv.put("rm", rm);
             iv.invokeFunction("act");
         } catch (final ScriptException | NoSuchMethodException | NullPointerException e) {
             FilePrinter.printError(FilePrinter.REACTOR + reactor.getId() + ".txt", e);
@@ -116,11 +118,11 @@ public class ReactorScriptManager extends AbstractScriptManager {
 
     public synchronized void touching(MapleClient c, MapleReactor reactor, boolean touching) {
         try {
-            Invocable iv = getInvocable("reactor/" + reactor.getId() + ".js", c);
+            NashornScriptEngine iv = getScriptEngine("reactor/" + reactor.getId() + ".js", c);
             if (iv == null) return;
             
             ReactorActionManager rm = new ReactorActionManager(c, reactor, iv);
-            engine.put("rm", rm);
+            iv.put("rm", rm);
             if (touching) {
                 iv.invokeFunction("touch");
             } else {


### PR DESCRIPTION
In order to make it easier to work with scripting, we need to clean up the base class:

* Remove references to `Invocable`. We require that we find a `NashornScriptEngine` (as finding another ScriptEngine is catastophic anyways). Since NashornScriptEngine is an `Invocable`, we don't need these extra casts.
* Remove potentially dangerous cache of `engine`. 