### PR TITLE
Fix stuck players when other player denies match request

### DIFF
--- a/src/net/server/coordinator/MapleMatchCheckerCoordinator.java
+++ b/src/net/server/coordinator/MapleMatchCheckerCoordinator.java
@@ -300,7 +300,7 @@ public class MapleMatchCheckerCoordinator {
     }
     
     private void disposeMatchElement(MapleMatchCheckingElement mmce) {
-        Set<Integer> matchPlayers = mmce.getAcceptedMatchPlayers();
+        Set<Integer> matchPlayers = mmce.getMatchPlayers();
         while (!poolMatchPlayers(matchPlayers)) {
             try {
                 Thread.sleep(1000);

--- a/src/net/server/coordinator/matchchecker/listener/MatchCheckerGuildCreation.java
+++ b/src/net/server/coordinator/matchchecker/listener/MatchCheckerGuildCreation.java
@@ -159,7 +159,7 @@ public class MatchCheckerGuildCreation implements MatchCheckerListenerRecipe {
                     }
                     
                     if (chr.isLoggedinWorld()) {
-                        chr.announce(MaplePacketCreator.genericGuildMessage((byte)0x24));
+                        chr.announce(MaplePacketCreator.genericGuildMessage((byte)0x26));
                     }
                 }
             }
@@ -189,6 +189,7 @@ public class MatchCheckerGuildCreation implements MatchCheckerListenerRecipe {
                     
                     if (chr.isLoggedinWorld()) {
                         chr.message(msg);
+                        chr.announce(MaplePacketCreator.genericGuildMessage((byte)0x26));
                     }
                 }
             }


### PR DESCRIPTION
Only players that were accepted before are disposed from this current `MapleMatchCheckingElement`; when disposing an entire match element, we should free all players from this match.