### PR TITLE
Repeat question if user has wrong pass count

### DIFF
--- a/scripts/npc/9020001.js
+++ b/scripts/npc/9020001.js
@@ -170,7 +170,8 @@ function action(mode, type, selection) {
                                                         eim.gridInsert(cm.getPlayer(), 0);
                                                 }
                                                 else {
-                                                        cm.sendNext("I'm sorry, but that is not the right answer! Please have the correct number of coupons in your inventory.");
+                                                        var question = stage1Questions[eim.gridCheck(cm.getPlayer()) - 1];
+                                                        cm.sendNext("I'm sorry, but that is not the right answer!\r\n" + question);
                                                 }
                                         }
                                 }


### PR DESCRIPTION
## Background
- NPC Name: Cloto
- Location: Kerning City PQ Stage 1 (Ligator hunt)

## Info
- In HeavenMS, she would tell the user they had the wrong number of passes, but not repeat the question.
- This was mainly a problem for those who missed the question the first time it was asked.
- With this fix, Cloto follows up with her 'wrong answer' speech, and repeats the proper question associated with the given player.

## Additional notes / follow up
I'm new to all of this :sweat_drops:, so if this isn't the best way to do it, let me know and I hope to do it right next time! :grin: (such as adding it in a next window rather than being squishied into the same one) :cake: