### PR TITLE
Adds a check for when USE_ENFORCE_NOVICE_EXPRATE and USE_QUEST_RATE are both on

### DIFF
--- a/src/client/MapleCharacter.java
+++ b/src/client/MapleCharacter.java
@@ -4827,6 +4827,10 @@ public class MapleCharacter extends AbstractMapleCharacterObject {
     }
     
     public int getQuestExpRate() {
+        if (hasNoviceExpRate()) {
+            return 1;
+        }
+        
         World w = getWorldServer();
         return w.getExpRate() * w.getQuestRate();
     }


### PR DESCRIPTION
Apologies for the commit name's incorrect issue reference, I don't know how to change its name :sob:

The original issue was that when the two following flags in ServerConstants are true, quests for players affected by the 1x exp rate retain the server's quest rate and do not receive 1x quest exp.
- USE_QUEST_RATE
- USE_ENFORCE_NOVICE_EXPRATE

This fix adds the check that enforces quest exp rate of 1x if USE_ENFORCE_NOVICE_EXPRATE is on.