### PR TITLE
Fix mob DR skills to GMS-like

### DIFF
--- a/src/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/src/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -521,7 +521,7 @@ public abstract class AbstractDealDamageHandler extends AbstractMaplePacketHandl
                         
                         map.damageMonster(player, monster, totDamageToOneMonster);
                     }
-                    if (monster.isBuffed(MonsterStatus.WEAPON_REFLECT)) {
+                    if (monster.isBuffed(MonsterStatus.WEAPON_REFLECT) && !attack.magic) {
                         List<Pair<Integer, Integer>> mobSkills = monster.getSkills();
                         
                         for (Pair<Integer, Integer> ms : mobSkills) {
@@ -532,13 +532,14 @@ public abstract class AbstractDealDamageHandler extends AbstractMaplePacketHandl
                             }
                         }
                     }                
-                    if (monster.isBuffed(MonsterStatus.MAGIC_REFLECT)) {
+                    if (monster.isBuffed(MonsterStatus.MAGIC_REFLECT) && attack.magic) {
                         List<Pair<Integer, Integer>> mobSkills = monster.getSkills();
                         
                         for (Pair<Integer, Integer> ms : mobSkills) {
                             if (ms.left == 145) {
                                 MobSkill toUse = MobSkillFactory.getMobSkill(ms.left, ms.right);
-                                player.addMP(-toUse.getY());
+                                player.addHP(-toUse.getY());
+                                map.broadcastMessage(player, MaplePacketCreator.damagePlayer(0, monster.getId(), player.getId(), toUse.getY(), 0, 0, false, 0, true, monster.getObjectId(), 0, 0), true);
                             }
                         }
                     }


### PR DESCRIPTION
In Maplestory, there are three reflection buffs:
- Physical Reflect
- Magical Reflect
- Mixed Reflect (both combined)

Physical reflect would only reflect damage to physical users, Magical would only reflect to magical users, Mixed would reflect to both users.

In HeavenMS, the reflects are treated as an HP reflect and MP reflect, so the vanilla reflection mechanic was implemented here in this commit

I couldn't seem to recall any mobs that only had one or the other, so the best I could test with was Munin or Hugin (whichever's id was 8820005) but all three debuffs worked properly with that bird :grin: