### PR TITLE
Fix cash shop bbsmojis

### DIFF
--- a/src/net/server/channel/handlers/BBSOperationHandler.java
+++ b/src/net/server/channel/handlers/BBSOperationHandler.java
@@ -56,7 +56,7 @@ public final class BBSOperationHandler extends AbstractMaplePacketHandler {
                 String text = correctLength(slea.readMapleAsciiString(), 600);
                 int icon = slea.readInt();
                 if (icon >= 0x64 && icon <= 0x6a) {
-                    if (c.getPlayer().haveItemWithId(5290000 + icon - 0x64, false)) {
+                    if (!c.getPlayer().haveItemWithId(5290000 + icon - 0x64, false)) {
                         return;
                     }
                 } else if (icon < 0 || icon > 3) {


### PR DESCRIPTION
They originally caused a BBS post to not send since the condition was true when the player correctly had the emoji icon in their inventory.