### PR TITLE
Overhaul of in-game text focusing on consumable items

### DIFF
--- a/wz/Quest.wz/Act.img.xml
+++ b/wz/Quest.wz/Act.img.xml
@@ -12775,8 +12775,16 @@
   </imgdir>
   <imgdir name="2236">
     <imgdir name="0">
+      <string name="info" value="000000"/>
+      <imgdir name="item">
+        <imgdir name="0">
+          <int name="id" value="4032263"/>
+          <int name="count" value="6"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
     <imgdir name="1">
+      <int name="exp" value="60000"/>
     </imgdir>
   </imgdir>
   <imgdir name="2237">
@@ -20077,6 +20085,7 @@
       </imgdir>
     </imgdir>
     <imgdir name="1">
+      <int name="pop" value="20"/>
     </imgdir>
   </imgdir>
   <imgdir name="3115">

--- a/wz/Quest.wz/Check.img.xml
+++ b/wz/Quest.wz/Check.img.xml
@@ -20136,6 +20136,12 @@
       <imgdir name="job">
         <int name="0" value="2110"/>
       </imgdir>
+      <int name="infoNumber" value="21203"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="1"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="1203001"/>
@@ -22133,7 +22139,12 @@
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="1061019"/>
-      <string name="endscript" value="q21728e"/>
+      <int name="infoNumber" value="21761"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="0"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="21729">
@@ -22307,6 +22318,12 @@
         <imgdir name="0">
           <int name="count" value="1"/>
           <int name="id" value="9300345"/>
+        </imgdir>
+      </imgdir>
+      <int name="infoNumber" value="21762"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="2"/>
         </imgdir>
       </imgdir>
     </imgdir>
@@ -23461,7 +23478,7 @@
       <imgdir name="mob">
         <imgdir name="0">
           <int name="id" value="5130101"/>
-          <int name="count" value="80"/>
+          <int name="count" value="100"/>
         </imgdir>
       </imgdir>
     </imgdir>
@@ -24184,10 +24201,15 @@
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="1061000"/>
-      <string name="endscript" value="q2236e"/>
       <imgdir name="item">
         <imgdir name="0">
           <int name="id" value="4032263"/>
+        </imgdir>
+      </imgdir>
+      <int name="infoNumber" value="2236"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="111111"/>
         </imgdir>
       </imgdir>
     </imgdir>
@@ -39696,7 +39718,11 @@
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="2012026"/>
-      <string name="endscript" value="q3114e"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="42"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="3115">
@@ -40748,7 +40774,6 @@
           <int name="count" value="1"/>
         </imgdir>
       </imgdir>
-      <string name="endscript" value="q3250e"/>
       <int name="infoNumber" value="7067"/>
       <imgdir name="infoex">
         <imgdir name="0">
@@ -41038,7 +41063,11 @@
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="2111000"/>
-      <string name="endscript" value="q3311e"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="5"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="3312">
@@ -41728,7 +41757,11 @@
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="2020005"/>
-      <string name="endscript" value="q3345e"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="4"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="3346">
@@ -42046,7 +42079,11 @@
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="2111006"/>
-      <string name="endscript" value="q3360e"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="1"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="3361">
@@ -48377,7 +48414,11 @@
           <int name="id" value="4031579"/>
         </imgdir>
       </imgdir>
-      <string name="endscript" value="q3926e"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="3333"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="3927">
@@ -48393,7 +48434,11 @@
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="2101000"/>
-      <string name="endscript" value="q3927e"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="1"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="3928">
@@ -48443,7 +48488,11 @@
           <int name="id" value="4031580"/>
         </imgdir>
       </imgdir>
-      <string name="endscript" value="q3929e"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="3333"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="3930">
@@ -50105,6 +50154,12 @@
     <imgdir name="0">
       <int name="npc" value="9120003"/>
       <int name="lvmin" value="55"/>
+      <imgdir name="quest">
+        <imgdir name="0">
+          <int name="id" value="4306"/>
+          <int name="state" value="2"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="9120003"/>
@@ -56931,6 +56986,11 @@
           <int name="count" value="1"/>
         </imgdir>
       </imgdir>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="1"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="6034">
@@ -60034,7 +60094,12 @@
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="2095000"/>
-      <string name="endscript" value="q6410e"/>
+      <int name="infoNumber" value="6411"/>
+      <imgdir name="infoex">
+        <imgdir name="0">
+          <string name="value" value="p2"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="6700">

--- a/wz/Quest.wz/QuestInfo.img.xml
+++ b/wz/Quest.wz/QuestInfo.img.xml
@@ -4581,7 +4581,7 @@ You can now begin the &quot;Manji&apos;s Request&quot; quest.
   <imgdir name="20718">
     <string name="name" value="Maybe it&apos;s Grendel!"/>
     <string name="0" value="I better talk to Agent #b#p1103003##k of #m101000000# about a new assignment."/>
-    <string name="1" value="#p1103003# told me #p1032001# looked very suspicious. She said she always had #p1032001# in mind every since she found out about his past, which involved dabbling with dangerous black magic. She then assigned me to visit #b#m101000003##k, where #p1032001# lives, and wanted me to conduct a #bfull search in his house#k while #p1032001# is away."/>
+    <string name="1" value="#p1103003# told me #p1032001# looked very suspicious. She said she always had #p1032001# in mind ever since she found out about his past, which involved dabbling with dangerous black magic. She then assigned me to visit #b#m101000003##k, where #p1032001# lives, and wanted me to conduct a #bfull search in his house#k while #p1032001# is away."/>
     <string name="2" value="While conducting a full search in #p1032001#&apos;s house, I was ambushed by a black shadow. Thankfully, I came out alive. After telling her what happened, #p1103003# stopped and started thinking about something..."/>
     <int name="area" value="15"/>
   </imgdir>
@@ -6467,7 +6467,7 @@ Once there, talk to #b#p1200003##k to board the ship.
   <imgdir name="2198">
     <string name="name" value="Eliminate the Stone Golems"/>
     <string name="0" value="Muirhat is worried about the evil spirits that have infiltrated Victoria Island as of late. I wonder what I could do to help? I should go talk to Muirhat on the top deck of The Nautilus."/>
-    <string name="1" value="Victoria Island has already been infused with evil spirits. But I refuse to give up like this. I need to eliminate #r80 Stone Golems#k to stop these evil creatures from further spreading their evilness in Victoria Island.  \n\n#o 5130101# #r#a21981##k"/>
+    <string name="1" value="Victoria Island has already been infused with evil spirits. But I refuse to give up like this. I need to eliminate #r100 Stone Golems#k to stop these evil creatures from further spreading their evilness in Victoria Island.  \n\n#o 5130101# #r#a21981##k"/>
     <string name="2" value="I&apos;ve eliminated 100 Stone Golems. I wonder if I&apos;ve made a difference in Victoria Island?"/>
     <int name="area" value="30"/>
   </imgdir>
@@ -12719,7 +12719,7 @@ Can proceed to the &quot;The Secrets Behind the Ring?&quot; quest.
   <imgdir name="3330">
     <string name="name" value="Keeny&apos;s Research on Neo Huroid!"/>
     <string name="0" value="#b#p2111005##k is the little Fairy who studies alchemy. She seems to be in need of help..."/>
-    <string name="1" value="#p2111005#&apos;s studies have now taken her ahead of #o5110301# and onto #o5110302#. #p2111005# said in order to thoroughly investigate #r#o5110302##k, she&apos;ll need #b#t4000365##k... \n\n#i4000365##t4000365# #b#c4000365##k/160 "/>
+    <string name="1" value="#p2111005#&apos;s studies have now taken her ahead of #o5110301# and on to #o5110302#. #p2111005# said in order to thoroughly investigate #r#o5110302##k, she&apos;ll need #b#t4000365##k... \n\n#i4000365##t4000365# #b#c4000365##k/160 "/>
     <string name="2" value="I gave #p2111005# all the #t4000365#s she asked for. She revealed that she learned alchemy from the Zenumist alchemists, but slowly found Alcadno&apos;s work fascinating, and is now conducting studies secret from the alchemists that have taught her."/>
     <int name="area" value="44"/>
   </imgdir>
@@ -13511,7 +13511,7 @@ Can proceed to the &quot;The Secrets Behind the Ring?&quot; quest.
     <string name="name" value="A Chat with Nara the Tour Guide"/>
     <string name="parent" value="VIP Ticket to Florina Beach"/>
     <int name="order" value="2"/>
-    <string name="1" value="Nara said a Ripped VIP pass will not work, nor can it be re-published, but the way to leave may be easier by paying a visit to Shuri, the the Tour Guide at Orbis."/>
+    <string name="1" value="Nara said a Ripped VIP pass will not work, nor can it be re-published, but the way to leave may be easier by paying a visit to Shuri, the tour guide at Orbis."/>
     <string name="2" value="Hmmm ... so something as simple as making a new ticket cannot be done, huh. Alright, since I&apos;m here and all, why don&apos;t I just take a crack at it til the very end?"/>
     <int name="area" value="37"/>
   </imgdir>
@@ -13520,7 +13520,7 @@ Can proceed to the &quot;The Secrets Behind the Ring?&quot; quest.
     <string name="parent" value="VIP Ticket to Florina Beach"/>
     <int name="order" value="3"/>
     <string name="1" value="I visited Shuri, and she mentioned that the VIP ticket cannot be re-issued, but it can be recovered. To recover the ripped VIP ticket, I&apos;ll need a few items... \n\n #t04000059# #b#c04000059##k/50 \n #t04000060# #b#c04000060##k/30 \n #t04021007# #b#c04021007##k/3"/>
-    <string name="2" value="After recovering the ripped VIP Ticket to Florina Beach, I was given the VIP Ticket to Florina Beach, a lifetime pass, as a sign of thanks.nNow it&apos;s a matter of taking a vacation whenever I want."/>
+    <string name="2" value="After recovering the ripped VIP Ticket to Florina Beach, I was given the VIP Ticket to Florina Beach, a lifetime pass, as a sign of thanks. Now it&apos;s a matter of taking a vacation whenever I want."/>
     <int name="area" value="37"/>
   </imgdir>
   <imgdir name="3444">
@@ -15338,7 +15338,7 @@ Can proceed to the &quot;The Secrets Behind the Ring?&quot; quest.
     <int name="order" value="2"/>
     <string name="0" value="After listening to #p2101000#, I realized they may be another secret organization besides Sand Bandits. Red Scorpions... who are they?"/>
     <string name="1" value="#p2101000# said that since the ring is from the Red Scorpions, who bully around people in the neighborhood, he stole it from them and gave it to others. What? So #p2101012# is a Red Scorpion? But he told me he&apos;s a Sand Bandit..."/>
-    <string name="2" value="#p2101000# said #p2101012# is fake, and I may want to find the hideaway spot of the Red Scorpions, which should be nearby. He said only a special password can open the door, and the only revenge for me to them would be to steal their stolen treasures and give them to others... by the way, what did he mean by &quot;I already know the password?&quot;"/>
+    <string name="2" value="#p2101000# said #p2101012# is fake, and I may want to find the hideaway spot of the Red Scorpions, which should be nearby. He said only a special password can open the door, and the only revenge for me to them would be to steal their stolen treasures and give them to others... By the way, what did he mean by &quot;I already know the password?&quot;"/>
     <int name="area" value="44"/>
   </imgdir>
   <imgdir name="3926">
@@ -16163,26 +16163,26 @@ Can proceed to the &quot;The Secrets Behind the Ring?&quot; quest.
     <string name="name" value="Angie&apos;s Beloved Costume 1"/>
     <string name="parent" value="Angie&apos;s Beloved Costume"/>
     <int name="order" value="1"/>
-    <string name="0" value="I think I just saw a Fashionable lady, #p9270032# in CBD waiving her hands at me!  Am I that Attractive?"/>
+    <string name="0" value="I think I just saw a Fashionable lady, #p9270032#, in CBD waving her hands at me! Am I that attractive?"/>
     <string name="1" value="#p9270032# has asked me to gather #b#t4000035##k and #b#t4000021##k in order to make a fashionable brand new Indian Costume.\n\n#t4000035#  #r#c4000035#/20#k\n#t4000021#  #r#c4000021#/20#k"/>
-    <string name="2" value="Now that I have brought all the required items to #p9270032#, I never have seen someboy so obssessed with her fashion that much.  Talking about the fashion, there is no one that dresses better than me in MapleS.E.A."/>
+    <string name="2" value="Now that I have brought all the required items to #p9270032#, I never have seen someboy so obsessed with her fashion that much. Talking about the fashion, there is no one who dresses better than me in MapleS.E.A."/>
     <int name="area" value="48"/>
   </imgdir>
   <imgdir name="4508">
     <string name="name" value="Angie&apos;s Beloved Costume 2"/>
     <string name="parent" value="Angie&apos;s Beloved Costume"/>
     <int name="order" value="2"/>
-    <string name="0" value="#p9270032# who is ossesed with fashion is looking for help once more.  What should it be this time?"/>
-    <string name="1" value="She is definately obssessed with fashion! She wants another dress. Wonder how many dresses she has in her closet.  Is she a fashion model or something?  Well, let&apos;s just give her what she needs.\n\n#t4000035#  #r#c4000035#/25#k\n#t4000021#  #r#c4000021#/25#k\n#t4021003#  #r#c4021003#/5"/>
-    <string name="2" value="Angie rewarded with carrot cake to me to show her appreciation for gathering her the items for her new clothes.  It looks so delicious."/>
+    <string name="0" value="#p9270032#, who is obsessed with fashion, is looking for help once more. What should it be this time?"/>
+    <string name="1" value="She is definitely obsessed with fashion! She wants another dress. Wonder how many dresses she has in her closet. Is she a fashion model or something? Well, let&apos;s just give her what she needs.\n\n#t4000035#  #r#c4000035#/25#k\n#t4000021#  #r#c4000021#/25#k\n#t4021003#  #r#c4021003#/5"/>
+    <string name="2" value="Angie rewarded carrot cake to me to show her appreciation for gathering the items for her new clothes. It looks so delicious."/>
     <int name="area" value="48"/>
   </imgdir>
   <imgdir name="4509">
     <string name="name" value="Angie&apos;s Beloved Costume 3"/>
     <string name="parent" value="Angie&apos;s Beloved Costume"/>
     <int name="order" value="3"/>
-    <string name="0" value="What?  #p9270032# in CBD is looking for me again?  I wonder what could it be this time!"/>
-    <string name="1" value="No surprise to find out that she wants a new dress!  She asked me to gather 50 #t4000035#, 50 #t4000021#, and 10 #t4021003# this time.  I really hope that she is satisfied with her dress!\n\n#t4000035#  #r#c4000035#/50#k\n#t4000021#  #r#c4000021#/50#k\n#t4021003#  #r#c4021003#/10#k"/>
+    <string name="0" value="What? #p9270032# in CBD is looking for me again? I wonder what could it be this time!"/>
+    <string name="1" value="No surprise to find out that she wants a new dress! She asked me to gather 50 #t4000035#, 50 #t4000021#, and 10 #t4021003# this time.  I really hope that she is satisfied with her dress!\n\n#t4000035#  #r#c4000035#/50#k\n#t4000021#  #r#c4000021#/50#k\n#t4021003#  #r#c4021003#/10#k"/>
     <string name="2" value="Phew... Finally, #p9270032# was able to get all dresses she ever wanted! But speaking of fashion, I am sure that I look much better!"/>
     <int name="area" value="48"/>
   </imgdir>
@@ -16190,9 +16190,9 @@ Can proceed to the &quot;The Secrets Behind the Ring?&quot; quest.
     <string name="name" value="The secret of the past"/>
     <string name="parent" value="The Secret of Ghostship"/>
     <int name="order" value="1"/>
-    <string name="0" value="#b#p9270030##k in Boat Quay looks like he could use some help of mine.  He seems very scared of something.  Let&apos;s go find out."/>
+    <string name="0" value="#b#p9270030##k in Boat Quay looks like he could use some help of mine. He seems very scared of something. Let&apos;s go find out."/>
     <string name="1" value="#p9270030# told me this weird story about a ghost ship and ghosts along the coast line. Shall I believe him? He is just a nameless wanderer in town, but he seemed to be serious about the story. Let&apos;s go and find out if he is telling me the truth. There should be #b#o9420509##k and #b#o9420510##k somewhere around Boat Quay and I am about to eliminate them!\n\n#o9420509#  #r#a45101##k\n#o9420510#  #r#a45102##k"/>
-    <string name="2" value="What a surprise!  #p9270030# was telling me the truth!  I should go see him again since I feel that there are more stories he wants to tell me!"/>
+    <string name="2" value="What a surprise! #p9270030# was telling me the truth! I should go see him again since I feel that there are more stories he wants to tell me!"/>
     <int name="area" value="48"/>
   </imgdir>
   <imgdir name="4511">
@@ -16200,40 +16200,40 @@ Can proceed to the &quot;The Secrets Behind the Ring?&quot; quest.
     <string name="parent" value="The Secret of Ghostship"/>
     <int name="order" value="2"/>
     <string name="0" value="#b#p9270030##k has more secrets to reveal!  Let&apos;s go see him again!"/>
-    <string name="1" value="#b#p9270030##k has told me that he wishes to sail again with his crew.  However, he isn&apos;t sure if he can go out to the sea like the old days because of the Ghosts along the coast line.  I really want to help him get his dream back by eliminating #b#o9420510# and #o9420511##k.\n\n#o9420510#  #r#a45111##k\n#o9420511#  #r#a45112##k"/>
-    <string name="2" value="Yes indeed!  I did help #p9270030# to get back to the sea again.  But I wonder, he has something more worried about.  I think I should go see him again."/>
+    <string name="1" value="#b#p9270030##k has told me that he wishes to sail again with his crew. However, he isn&apos;t sure if he can go out to the sea like the old days because of the Ghosts along the coast line.  I really want to help him get his dream back by eliminating #b#o9420510# and #o9420511##k.\n\n#o9420510#  #r#a45111##k\n#o9420511#  #r#a45112##k"/>
+    <string name="2" value="Yes indeed!  I did help #p9270030# to get back to the sea again. But I wonder, he has something more worried about.  I think I should go see him again."/>
     <int name="area" value="48"/>
   </imgdir>
   <imgdir name="4512">
     <string name="name" value="The great secret reveals"/>
     <string name="parent" value="The Secret of Ghostship"/>
     <int name="order" value="3"/>
-    <string name="0" value="#b#p9270030##k is about to reveal more about his secrets!  Let&apos;s go find him Boat Quay."/>
-    <string name="1" value="The most strongest ghost, #b#o9420512##k is the one that #p9270030# was so afraid of...  Well I am not afraid of anything!  He asked me to help him get back to the sea by eliminating #b300 #o9420512##k.  He told me to bring my friends with me since this ghost is the most powerful one in town.  Follow me my fellow Maplers!\n\n#o9420512#  #r#a45121##k"/>
-    <string name="2" value="Eliminating #o9420512# was not a easy task for me but I did it!  Now, I should go see #p9270030# and see if he has left to the sea.  Or.. does he have another serious secret, something Big?"/>
+    <string name="0" value="#b#p9270030##k is about to reveal more about his secrets! Let&apos;s go find him at Boat Quay."/>
+    <string name="1" value="The most strongest ghost, #b#o9420512##k is the one that #p9270030# was so afraid of... Well I am not afraid of anything!  He asked me to help him get back to the sea by eliminating #b300 #o9420512##k.  He told me to bring my friends with me since this ghost is the most powerful one in town.  Follow me my fellow Maplers!\n\n#o9420512#  #r#a45121##k"/>
+    <string name="2" value="Eliminating #o9420512# was not a easy task for me but I did it! Now, I should go see #p9270030# and see if he has left to the sea.  Or.. does he have another serious secret, something Big?"/>
     <int name="area" value="48"/>
   </imgdir>
   <imgdir name="4513">
     <string name="name" value="Fight for the future"/>
     <string name="parent" value="The Secret of Ghostship"/>
     <int name="order" value="4"/>
-    <string name="0" value="I sense something that #p9270030# has not told me all of his secrets.  There is still something about this Ghosthip.  Let&apos;s go find out."/>
-    <string name="1" value="Believe or not, #p9270030# told me that there is this Boss Ghost, #r#o9420513##k who controlls all other ghosts in town.  Without defeating this monster, the boat quay will never be the same.  Let go investigate the Ghostship now.  But I must be cautious since he also said theGhostship itself is a big maze...  I will have to eliminate #o9420513# and collect #t4000384# as a proof of elimination.\n\n#o9420513#  #r#a45131##k\n#t4000384#  #r#c4000384#/1#k"/>
-    <string name="2" value="What an exprience!  I am glad that I brought peace to this town and to the sailors!  However, I feel that the ghost has not been perfectly disappeared.  I should go check every once in a while."/>
+    <string name="0" value="I sense something that #p9270030# has not told me all of his secrets. There is still something about this Ghostship. Let&apos;s go find out."/>
+    <string name="1" value="Believe it or not, #p9270030# told me that there is this Boss Ghost, #r#o9420513##k, who controls all other ghosts in town. Without defeating this monster, the boat quay will never be the same. Let go investigate the Ghostship now. But I must be cautious since he also said the Ghostship itself is a big maze... I will have to eliminate #o9420513# and collect #t4000384# as proof of elimination.\n\n#o9420513#  #r#a45131##k\n#t4000384#  #r#c4000384#/1#k"/>
+    <string name="2" value="What an experience! I am glad that I brought peace to this town and to the sailors! However, I feel that the ghost has not completely disappeared. I should go check every once in a while."/>
     <int name="area" value="48"/>
   </imgdir>
   <imgdir name="4522">
     <string name="name" value="The Lost White Essence"/>
     <string name="0" value="If I lost the #bwhite essence#k, I should go visit #bRalph the wanderer#k again."/>
-    <string name="1" value="I should go eliminate Mr. Anchor once more and gather the red essence.  I should really take care of the White Essence this time if Ralph the wanderer gives me the item this time.\n\n#o9420512#  #r#a45221##k\n#t4000383#  #r#c4000383#/300"/>
+    <string name="1" value="I should go eliminate Mr. Anchor once more and gather the red essence. I should really take care of the White Essence this time if Ralph the wanderer gives me the item this time.\n\n#o9420512#  #r#a45221##k\n#t4000383#  #r#c4000383#/300"/>
     <string name="2" value="Phew... I really should go take care of the #bCapt. Latanica#k this time and bring peace to the Boat Quay Town."/>
     <int name="area" value="48"/>
   </imgdir>
   <imgdir name="4523">
     <string name="name" value="Return of Capt. Latanica"/>
-    <string name="0" value="#bRalph the wanderer#k is sensing dark force around the Ghostship Area...  I have to check him out once again."/>
-    <string name="1" value="#bRalph the wanderer#k believes that #rCapt. Latanica#k is back!!!  He wanted me to enter the engine room once again, but he needs to find out that I am still in shape. I will have to prove to him that I have been training myself and am prepared.\n\n"/>
-    <string name="2" value="I was finally able to prove to him that I am still prepared to enter the engine room.  Now, Capt. Latanica is all mine!"/>
+    <string name="0" value="#bRalph the wanderer#k is sensing dark force around the Ghostship Area... I have to check him out once again."/>
+    <string name="1" value="#bRalph the wanderer#k believes that #rCapt. Latanica#k is back!!! He wanted me to enter the engine room once again, but he needs to find out that I am still in shape. I will have to prove to him that I have been training myself and am prepared.\n\n"/>
+    <string name="2" value="I was finally able to prove to him that I am still prepared to enter the engine room. Now, Capt. Latanica is all mine!"/>
     <int name="area" value="48"/>
   </imgdir>
   <imgdir name="4541">
@@ -16241,7 +16241,7 @@ Can proceed to the &quot;The Secrets Behind the Ring?&quot; quest.
     <string name="parent" value="Malek&apos;s Joy of Music"/>
     <int name="order" value="1"/>
     <string name="0" value="It is such a sunny day! I really need something to cool down!"/>
-    <string name="1" value="#b#p9270061##k says that with the #b#o9420527#s#k running outside the village, we won&apos;t be able to go out of the Kampung.They want me to help get rid of them and collect #b50 #t4000465#s#k. \n\n#t4000465# #r#c4000465#/50#k"/>
+    <string name="1" value="#b#p9270061##k says that with the #b#o9420527#s#k running outside the village, we won&apos;t be able to go out of the Kampung. They want me to help get rid of them and collect #b50 #t4000465#s#k. \n\n#t4000465# #r#c4000465#/50#k"/>
     <string name="2" value="After getting the #b#t4000465##k they felt less heaty."/>
     <int name="area" value="49"/>
     <string name="demandSummary" value="#i4000465:# #t4000465:# #c4000465# / 50
@@ -17605,7 +17605,7 @@ Able to proceed to &apos;Merry-go-round in Kampung&apos; as next quest.
   <imgdir name="6031">
     <string name="name" value="Hughes the Fuse&apos;s Basic Theory of Science"/>
     <string name="0" value="When I visited Meren to learn his new method, he instructed me to attend a class on the Basic Theory of Science taught by that eccentric scientist Hughes the Fuse. This worries me quite a bit..."/>
-    <string name="1" value="Meren said in order to attend the class on the Fundamentals of Alchemy, I must visit #bHughes the Fuse#k, who is holed up somehwere inside Orbis Tower, doing his own thing."/>
+    <string name="1" value="Meren said in order to attend the class on the Fundamentals of Alchemy, I must visit #bHughes the Fuse#k, who is holed up somewhere inside Orbis Tower, doing his own thing."/>
     <string name="2" value="I was able to keep track of Hughes the Fuse&apos;s disorienting science class. Yay!!"/>
     <int name="area" value="10"/>
   </imgdir>

--- a/wz/String.wz/Consume.img.xml
+++ b/wz/String.wz/Consume.img.xml
@@ -18,7 +18,7 @@
   </imgdir>
   <imgdir name="2000004">
     <string name="name" value="Elixir"/>
-    <string name="desc" value="A legendary potion.\nRecovers 50%  HP and 50% MP."/>
+    <string name="desc" value="A legendary potion.\nRecovers 50% HP and 50% MP."/>
   </imgdir>
   <imgdir name="2000005">
     <string name="name" value="Power Elixir"/>
@@ -30,23 +30,23 @@
   </imgdir>
   <imgdir name="2000007">
     <string name="name" value="Red Pill"/>
-    <string name="desc" value="A pill of concentrated red potion, which restores 50 HP. You can carry more pills than potions because they&apos;re smaller"/>
+    <string name="desc" value="A pill of concentrated red potion, which restores 50 HP. You can carry more pills than potions because they&apos;re smaller."/>
   </imgdir>
   <imgdir name="2000008">
     <string name="name" value="Orange Pill"/>
-    <string name="desc" value="A pill of concentrated orange potion, which restores 150 HP. You can carry more pills than potions because they&apos;re smaller"/>
+    <string name="desc" value="A pill of concentrated orange potion, which restores 150 HP. You can carry more pills than potions because they&apos;re smaller."/>
   </imgdir>
   <imgdir name="2000009">
     <string name="name" value="White Pill"/>
-    <string name="desc" value="A pill of concentrated white potion, which restores 300 HP. You can carry more pills than potions because they&apos;re smaller"/>
+    <string name="desc" value="A pill of concentrated white potion, which restores 300 HP. You can carry more pills than potions because they&apos;re smaller."/>
   </imgdir>
   <imgdir name="2000010">
     <string name="name" value="Blue Pill"/>
-    <string name="desc" value="A pill of concentrated blue potion, which restores 100 MP. You can carry more pills than potions because they&apos;re smaller"/>
+    <string name="desc" value="A pill of concentrated blue potion, which restores 100 MP. You can carry more pills than potions because they&apos;re smaller."/>
   </imgdir>
   <imgdir name="2000011">
     <string name="name" value="Mana Elixir Pill"/>
-    <string name="desc" value="A pill of concentrated Mana Elixir, which restores 300 MP. You can carry more pills than potions because they&apos;re smaller"/>
+    <string name="desc" value="A pill of concentrated Mana Elixir, which restores 300 MP. You can carry more pills than potions because they&apos;re smaller."/>
   </imgdir>
   <imgdir name="2000012">
     <string name="name" value="Elixir"/>
@@ -54,11 +54,11 @@
   </imgdir>
   <imgdir name="2000013">
     <string name="name" value="Red Potion for Beginners"/>
-    <string name="desc" value="A potion made out of red herbs made especially for beginners. \nRecovers 40 HP."/>
+    <string name="desc" value="A potion made out of red herbs made especially for beginners.\nRecovers 40 HP."/>
   </imgdir>
   <imgdir name="2000014">
     <string name="name" value="Blue Potion for Beginners"/>
-    <string name="desc" value="A potion made out of blue herbs made especially for beginners. \nRecovers 80 MP."/>
+    <string name="desc" value="A potion made out of blue herbs made especially for beginners.\nRecovers 80 MP."/>
   </imgdir>
   <imgdir name="2000015">
     <string name="name" value="Orange Potion for Beginners"/>
@@ -90,7 +90,7 @@
   </imgdir>
   <imgdir name="2001002">
     <string name="name" value="Red Bean Sundae"/>
-    <string name="desc" value="Definitely lets you forget about the hot hot summer. \nRecovers around 2000 MP."/>
+    <string name="desc" value="Definitely lets you forget about the hot hot summer.\nRecovers around 2000 MP."/>
   </imgdir>
   <imgdir name="2002000">
     <string name="name" value="Dexterity Potion"/>
@@ -118,19 +118,19 @@
   </imgdir>
   <imgdir name="2002006">
     <string name="name" value="Warrior Pill"/>
-    <string name="desc" value="A pill of concentrated warrior potion. Att. + 5 for 10 minutes"/>
+    <string name="desc" value="A pill of concentrated warrior potion. Attack +5 for 10 minutes."/>
   </imgdir>
   <imgdir name="2002007">
     <string name="name" value="Magic Pill"/>
-    <string name="desc" value="A pill of concentrated magic potion. Magic Att. + 5 for 10 minutes"/>
+    <string name="desc" value="A pill of concentrated magic potion. Magic Attack +5 for 10 minutes."/>
   </imgdir>
   <imgdir name="2002008">
     <string name="name" value="Sniper Pill"/>
-    <string name="desc" value="A pill of concentrated sniper potion. Accuracy + 10 for 10 minutes"/>
+    <string name="desc" value="A pill of concentrated sniper potion. Accuracy +10 for 10 minutes."/>
   </imgdir>
   <imgdir name="2002009">
     <string name="name" value="Dexterity Pill"/>
-    <string name="desc" value="A pill of concentrated dexterity potion. Avoidability + 10 for 10 minutes"/>
+    <string name="desc" value="A pill of concentrated dexterity potion. Avoidability +10 for 10 minutes."/>
   </imgdir>
   <imgdir name="2002010">
     <string name="name" value="Speed Pill"/>
@@ -138,7 +138,7 @@
   </imgdir>
   <imgdir name="2002011">
     <string name="name" value="Pain Reliever"/>
-    <string name="desc" value="A special pain reliever created in Omega Sector.nWeapon Def + 30 for 30 min."/>
+    <string name="desc" value="A special pain reliever created in Omega Sector.\nWeapon Def +30 for 30 min."/>
   </imgdir>
   <imgdir name="2002015">
     <string name="name" value="Elpam Elixir"/>
@@ -150,7 +150,7 @@
   </imgdir>
   <imgdir name="2002017">
     <string name="name" value="Warrior Elixir"/>
-    <string name="desc" value="A special elixir for Warriors. Gives +12 W. Att for 8 minutes."/>
+    <string name="desc" value="A special elixir for Warriors. Gives +12 W.Att for 8 minutes."/>
   </imgdir>
   <imgdir name="2002018">
     <string name="name" value="Wizard Elixir"/>
@@ -190,27 +190,27 @@
   </imgdir>
   <imgdir name="2002027">
     <string name="name" value="Stirge Signal"/>
-    <string name="desc" value="A makeshift device that looks like it&apos;s been duct-taped together.  Can be used to distract enemies... slightly.  [Gives +5 Avoidability for 20 minutes.]"/>
+    <string name="desc" value="A makeshift device that looks like it&apos;s been duct-taped together. Can be used to distract enemies... slightly.\n[Avoidability +5, lasts for 20 minutes.]"/>
   </imgdir>
   <imgdir name="2002028">
     <string name="name" value="T-1337 Supercharger"/>
-    <string name="desc" value="A charger for an advanced model cyborg. Looks like it would give quite a shock to the system! [Gives +25 Weapon Attack, +60 Magic Attack for 20 minutes.]"/>
+    <string name="desc" value="A charger for an advanced model cyborg. Looks like it would give quite a shock to the system!\n[Weapon Attack +25, Magic Attack +60, lasts for 20 minutes.]"/>
   </imgdir>
   <imgdir name="2002029">
     <string name="name" value="Ridley&apos;s Scroll of Defense"/>
-    <string name="desc" value="Why wear cumbersome armor when Ridley can provide the same protection, weightlessly and more comfortably!  (Legal Disclaimer: Effect is temporary) [Gives +100 Overall Defense for 10 minutes.]"/>
+    <string name="desc" value="Why wear cumbersome armor when Ridley can provide the same protection, weightlessly and more comfortably! (Legal Disclaimer: Effect is temporary)\n[Weapon Defense +100, Magic Defense +100, lasts for 10 minutes.]"/>
   </imgdir>
   <imgdir name="2010000">
     <string name="name" value="Apple"/>
-    <string name="desc" value="A red, ripe, and tasty apple.\nRecovers around 30 HP"/>
+    <string name="desc" value="A red, ripe, and tasty apple.\nRecovers around 30 HP."/>
   </imgdir>
   <imgdir name="2010001">
     <string name="name" value="Meat"/>
-    <string name="desc" value="A tasty-looking meat. .\nRecovers around 100 HP."/>
+    <string name="desc" value="A tasty-looking meat.\nRecovers around 100 HP."/>
   </imgdir>
   <imgdir name="2010002">
     <string name="name" value="Egg"/>
-    <string name="desc" value="A nutritious egg.nImproves around 50 HP."/>
+    <string name="desc" value="A nutritious egg.\nImproves around 50 HP."/>
   </imgdir>
   <imgdir name="2010003">
     <string name="name" value="Orange"/>
@@ -222,7 +222,7 @@
   </imgdir>
   <imgdir name="2010005">
     <string name="name" value="Honey"/>
-    <string name="desc" value="Fresh honey extracted from the beehive. \nRecovers around 30% of both HP and MP."/>
+    <string name="desc" value="Fresh honey extracted from the beehive.\nRecovers around 30% of both HP and MP."/>
   </imgdir>
   <imgdir name="2010006">
     <string name="name" value="Pot of Honey"/>
@@ -242,19 +242,19 @@
   </imgdir>
   <imgdir name="2012000">
     <string name="name" value="Drake&apos;s Blood"/>
-    <string name="desc" value="Drake&apos;s blood. nAttack +8 for 5 min."/>
+    <string name="desc" value="Drake&apos;s blood.\nAttack +8 for 5 min."/>
   </imgdir>
   <imgdir name="2012001">
     <string name="name" value="Fairy&apos;s Honey"/>
-    <string name="desc" value="It&apos;s honey, the fairies&apos; favorite.nAvoidability +10 for 5 min."/>
+    <string name="desc" value="It&apos;s honey, the fairies&apos; favorite.\nAvoidability +10 for 5 min."/>
   </imgdir>
   <imgdir name="2012002">
     <string name="name" value="Sap of Ancient Tree"/>
-    <string name="desc" value="Sap of a thousands-of-years-old tree. \nMagic Attack +10 for 5 min."/>
+    <string name="desc" value="Sap of a thousands-of-years-old tree.\nMagic Attack +10 for 5 min."/>
   </imgdir>
   <imgdir name="2012003">
     <string name="name" value="Drake&apos;s Meat"/>
-    <string name="desc" value="Drake&apos;s meat.nWeapon Def. +10 for 5 min."/>
+    <string name="desc" value="Drake&apos;s meat.\nWeapon Def. +10 for 5 min."/>
   </imgdir>
   <imgdir name="2020000">
     <string name="name" value="Salad"/>
@@ -290,35 +290,35 @@
   </imgdir>
   <imgdir name="2020008">
     <string name="name" value="Fat Sausage"/>
-    <string name="desc" value="Tastes great, and is quite nutritious. Recovers 1200 HP."/>
+    <string name="desc" value="Tastes great, and is quite nutritious.\nAllows you to recover about 1200 HP."/>
   </imgdir>
   <imgdir name="2020009">
     <string name="name" value="Orange Juice"/>
-    <string name="desc" value="Pure OJ... Recovers 450 MP."/>
+    <string name="desc" value="Pure OJ... Recovers around 450 MP."/>
   </imgdir>
   <imgdir name="2020010">
     <string name="name" value="Grape Juice"/>
-    <string name="desc" value="Used real grapes for this. Recovers 900 MP."/>
+    <string name="desc" value="Used real grapes for this. Recovers around 900 MP."/>
   </imgdir>
   <imgdir name="2020011">
     <string name="name" value="W Ramen"/>
-    <string name="desc" value="A cup ramen with awesome soup.\nRecovers 40% of HP and MP.."/>
+    <string name="desc" value="A cup ramen with awesome soup.\nRecovers 40% of HP and MP."/>
   </imgdir>
   <imgdir name="2020012">
     <string name="name" value="Melting Cheese"/>
-    <string name="desc" value="A mouth-watering cheese made out of fresh milk.\nRecovers 4000 HP."/>
+    <string name="desc" value="A mouth-watering cheese made out of fresh milk.\nRecovers around 4000 HP."/>
   </imgdir>
   <imgdir name="2020013">
     <string name="name" value="Reindeer Milk"/>
-    <string name="desc" value="Fresh milk squeezed out of a reindeer.\nRecovers 5000 HP."/>
+    <string name="desc" value="Fresh milk squeezed out of a goat.\nRecovers around 5000 HP."/>
   </imgdir>
   <imgdir name="2020014">
     <string name="name" value="Sunrise Dew"/>
-    <string name="desc" value="Dew collected early morning. Recovers 4000 MP"/>
+    <string name="desc" value="Dew collected out of the early-morning shower.\nRecovers 4050 MP"/>
   </imgdir>
   <imgdir name="2020015">
     <string name="name" value="Sunset Dew"/>
-    <string name="desc" value="Dew collected late in the afternoon. Recovers 5000 MP."/>
+    <string name="desc" value="Dew collected late in the afternoon.\nRecovers 5000 MP."/>
   </imgdir>
   <imgdir name="2020016">
     <string name="name" value="Cheesecake"/>
@@ -346,11 +346,11 @@
   </imgdir>
   <imgdir name="2020022">
     <string name="name" value="White Chocolate"/>
-    <string name="desc" value="A very delicious, home-made white chocolate. Attack + 5 for 30 minutes."/>
+    <string name="desc" value="A very delicious, home-made white chocolate. Attack +5 for 30 minutes."/>
   </imgdir>
   <imgdir name="2020023">
     <string name="name" value="Dark Chocolate"/>
-    <string name="desc" value="A very delicious, home-made dark chocolate. Magic Attack + 5 for 30 minutes."/>
+    <string name="desc" value="A very delicious, home-made dark chocolate. Magic Attack +5 for 30 minutes."/>
   </imgdir>
   <imgdir name="2020024">
     <string name="name" value="Chocolate Basket"/>
@@ -362,7 +362,7 @@
   </imgdir>
   <imgdir name="2020026">
     <string name="name" value="Strawberry Candy"/>
-    <string name="desc" value="A very sweet, home-made strawberry candy. Magic Att. +5 for 30 minutes."/>
+    <string name="desc" value="A very sweet, home-made strawberry candy. Magic Attack +5 for 30 minutes."/>
   </imgdir>
   <imgdir name="2020027">
     <string name="name" value="Candy Basket"/>
@@ -378,7 +378,7 @@
   </imgdir>
   <imgdir name="2020030">
     <string name="name" value="Roasted Turkey"/>
-    <string name="desc" value="A well-roasted turkey enough to feed the whole family.\nRecovers 100 HP."/>
+    <string name="desc" value="A well roasted turkey enough to feed the whole family.\nRecovers 100 HP."/>
   </imgdir>
   <imgdir name="2020031">
     <string name="name" value="Coca_Cola"/>
@@ -394,7 +394,7 @@
   </imgdir>
   <imgdir name="2022001">
     <string name="name" value="Red Bean Porridge"/>
-    <string name="desc" value="A hot steamy porridge made out of red beans. At an HP-decreasing map, whenever such map damage is dealt, 10 HP will be protected."/>
+    <string name="desc" value="A hot steamy porridge made out of red beans. At a HP-decreasing map, whenever such map damage is dealt, 10 HP will be protected."/>
   </imgdir>
   <imgdir name="2022002">
     <string name="name" value="Cider"/>
@@ -406,11 +406,11 @@
   </imgdir>
   <imgdir name="2022004">
     <string name="name" value="Song Pyun"/>
-    <string name="desc" value="Filled with royal jelly.\nRecovers 1500 HP."/>
+    <string name="desc" value="Filled with royal jelly.\nRecovers around 1500 HP."/>
   </imgdir>
   <imgdir name="2022005">
     <string name="name" value="Han Gwa"/>
-    <string name="desc" value="A traditional Korean snack.\nRecovers 1500 MP."/>
+    <string name="desc" value="A traditional Korean snack.\nRecovers around 1500 MP."/>
   </imgdir>
   <imgdir name="2022006">
     <string name="name" value="Rice-Cake Soup"/>
@@ -418,23 +418,23 @@
   </imgdir>
   <imgdir name="2022007">
     <string name="name" value="Triangular Sushi(plum)"/>
-    <string name="desc" value="A nice triangular sushi with plum in it. \nRecovers 20% of both HP and MP."/>
+    <string name="desc" value="A nice triangular sushi with plum in it.\nRecovers 20% of both HP and MP."/>
   </imgdir>
   <imgdir name="2022008">
     <string name="name" value="Triangular Sushi(salmon)"/>
-    <string name="desc" value="A nice triangular sushi with salmon in it. \nRecovers 30% of both HP and MP."/>
+    <string name="desc" value="A nice triangular sushi with salmon in it.\nRecovers 30% of both HP and MP."/>
   </imgdir>
   <imgdir name="2022009">
     <string name="name" value="Triangular Sushi(bonito)"/>
-    <string name="desc" value="A nice triangular sushi with bonito in it. \nRecovers 40% of both HP and MP."/>
+    <string name="desc" value="A nice triangular sushi with bonito in it.\nRecovers 40% of both HP and MP."/>
   </imgdir>
   <imgdir name="2022010">
     <string name="name" value="Triangular Sushi(pollack)"/>
-    <string name="desc" value="A nice triangular sushi with pollack in it. \nRecovers 50% of both HP and MP."/>
+    <string name="desc" value="A nice triangular sushi with pollack in it.\nRecovers 50% of both HP and MP."/>
   </imgdir>
   <imgdir name="2022011">
     <string name="name" value="Triangular Sushi(mushroom)"/>
-    <string name="desc" value="A nice triangular sushi with mushroom in it. \nRecovers 60% of both HP and MP."/>
+    <string name="desc" value="A nice triangular sushi with mushroom in it.\nRecovers 60% of both HP and MP."/>
   </imgdir>
   <imgdir name="2022012">
     <string name="name" value="Sushi(tuna)"/>
@@ -446,15 +446,15 @@
   </imgdir>
   <imgdir name="2022014">
     <string name="name" value="Dango"/>
-    <string name="desc" value="Taste the sweetness of this dango.\nRecovers 200 HP &amp; MP."/>
+    <string name="desc" value="Taste the sweetness of this dango.\nRecovers 200 HP and 200 MP."/>
   </imgdir>
   <imgdir name="2022015">
     <string name="name" value="Mushroom Miso Ramen"/>
-    <string name="desc" value="Only the finest ingredients are used to make this Miso Ramen.\nRecovers 80% for both HP and  MP."/>
+    <string name="desc" value="Only the finest ingredients are used to make this Miso Ramen.\nRecovers 80% for both HP and MP."/>
   </imgdir>
   <imgdir name="2022016">
     <string name="name" value="Maple Special Bento"/>
-    <string name="desc" value="A special bento with meat and mushroom.\nRecovers 500 for both HP and MP."/>
+    <string name="desc" value="A special bento with meat and mushroom.\nRecovers 500 HP and 500 MP."/>
   </imgdir>
   <imgdir name="2022017">
     <string name="name" value="Ramen"/>
@@ -486,19 +486,19 @@
   </imgdir>
   <imgdir name="2022024">
     <string name="name" value="Takoyaki (Octopus Ball)"/>
-    <string name="desc" value="A hot, tasty-looking Takoyaki.nAttack +8 for 5 minutes."/>
+    <string name="desc" value="A hot, tasty-looking Takoyaki.\nAttack +8 for 5 minutes."/>
   </imgdir>
   <imgdir name="2022025">
     <string name="name" value="Takoyaki (jumbo)"/>
-    <string name="desc" value="Two servings worth of Takoyaki.nAttack +8 for 10 minutes."/>
+    <string name="desc" value="Two servings worth of Takoyaki.\nAttack +8 for 10 minutes."/>
   </imgdir>
   <imgdir name="2022026">
     <string name="name" value="Yakisoba"/>
-    <string name="desc" value="A bowl of Yakisoba which includes vegetable, seafood, and noodles mixed with a delicious sauce.nMagic Attack +10 for 5 minutes."/>
+    <string name="desc" value="A bowl of Yakisoba which includes vegetable, seafood, and noodles mixed with a delicious sauce.\nMagic Attack +10 for 5 minutes."/>
   </imgdir>
   <imgdir name="2022027">
     <string name="name" value="Yakisoba (x2)"/>
-    <string name="desc" value="Double the serving of a normal bowl of Yakisoba which includes vegetable, seafood, and noodles mixed with a delicious sauce.nMagic Attack +10 for 10 minutes."/>
+    <string name="desc" value="Double the serving of a normal bowl of Yakisoba which includes vegetable, seafood, and noodles mixed with a delicious sauce.\nMagic Attack +10 for 10 minutes."/>
   </imgdir>
   <imgdir name="2022028">
     <string name="name" value="Valentine Chocolate (Dark)"/>
@@ -538,7 +538,7 @@
   </imgdir>
   <imgdir name="2022039">
     <string name="name" value="Nependeath&apos;s Honey"/>
-    <string name="desc" value="Recovers 1000 for both HP and MP."/>
+    <string name="desc" value="Both HP and MP will be recovered by 1000."/>
   </imgdir>
   <imgdir name="2022040">
     <string name="name" value="Air Bubble"/>
@@ -546,15 +546,15 @@
   </imgdir>
   <imgdir name="2022041">
     <string name="name" value="Fried shrimp"/>
-    <string name="desc" value="Recovers 500 of HP and MP."/>
+    <string name="desc" value="A fried shrimp that can be quite nutritious.\nRecovers 500 HP and MP."/>
   </imgdir>
   <imgdir name="2022042">
     <string name="name" value="Cookie"/>
-    <string name="desc" value="Crispy on the outside, marshmellow-soft on the inside, this cookie can be traced from afar by its sweet smell.nWeapon &amp; Magic Attack +20 for 30 minutes."/>
+    <string name="desc" value="Crispy on the outside, marshmellow-soft on the inside, this cookie can be traced from afar by its sweet smell.\nWeapon &amp; Magic Attack +20 for 30 minutes."/>
   </imgdir>
   <imgdir name="2022043">
     <string name="name" value="Fruity Candy"/>
-    <string name="desc" value="Multi-colored, fruity-flavored candies.nSpeed +10 for 30 minutes."/>
+    <string name="desc" value="Multi-colored, fruity-flavored candies.\nSpeed +10 for 30 minutes."/>
   </imgdir>
   <imgdir name="2022044">
     <string name="name" value="New Year Rice Cake"/>
@@ -614,19 +614,19 @@
   </imgdir>
   <imgdir name="2022060">
     <string name="name" value="Lotus Perfume"/>
-    <string name="desc" value="A perfume that contains power-boosting aroma. nAttack, Defense, Magic Attack +10 for 20 min."/>
+    <string name="desc" value="A perfume that contains power-boosting aroma.\nAttack, Defense, Magic Attack +10 for 20 min."/>
   </imgdir>
   <imgdir name="2022061">
     <string name="name" value="Oriental Perfume"/>
-    <string name="desc" value="A perfume that contains power-boosting aroma. nAttack, Defense, Magic Attack +15 for 20 min."/>
+    <string name="desc" value="A perfume that contains power-boosting aroma.\nAttack, Defense, Magic Attack +15 for 20 min."/>
   </imgdir>
   <imgdir name="2022062">
     <string name="name" value="Chrysanthemum Perfume"/>
-    <string name="desc" value="A perfume that contains power-boosting aroma. nAttack, Defense, Magic Attack +20 for 20 min."/>
+    <string name="desc" value="A perfume that contains power-boosting aroma.\nAttack, Defense, Magic Attack +20 for 20 min."/>
   </imgdir>
   <imgdir name="2022063">
     <string name="name" value="Corn Stick"/>
-    <string name="desc" value="A roasted corn on a skewer. Very delicious looking. \nRecovers HP 800."/>
+    <string name="desc" value="A roasted corn on a skewer. Very delicious looking.\nRecovers HP 800."/>
   </imgdir>
   <imgdir name="2022064">
     <string name="name" value="Fruit Stick"/>
@@ -634,11 +634,11 @@
   </imgdir>
   <imgdir name="2022065">
     <string name="name" value="Yellow Easter Egg"/>
-    <string name="desc" value="A freshly boiled egg colored in yellow. Recovers 100 HP and MP."/>
+    <string name="desc" value="A freshly boiled egg colored in yellow.\nRecovers 100 HP and MP."/>
   </imgdir>
   <imgdir name="2022066">
     <string name="name" value="Green Easter Egg"/>
-    <string name="desc" value="A freshly boiled egg colored in green. \nRecovers 200 HP and MP."/>
+    <string name="desc" value="A freshly boiled egg colored in green.\nRecovers 200 HP and MP."/>
   </imgdir>
   <imgdir name="2022068">
     <string name="name" value="Yellow Cider"/>
@@ -650,7 +650,7 @@
   </imgdir>
   <imgdir name="2022070">
     <string name="name" value="Congrats from GM"/>
-    <string name="desc" value="A mystical spell that can only be casted by a GM as a sign of congratulation. Weapon &amp; Magic Attack +20, Defense +100, Accuracy &amp; Avoidability +50, Speed &amp; Jump +10 for 1 HOUR."/>
+    <string name="desc" value="A mystical spell that can only be cast by a GM as a sign of congratulation. Weapon &amp; Magic Attack +20, Defense +100, Accuracy &amp; Avoidability +50, Speed &amp; Jump +10 for 1 HOUR."/>
   </imgdir>
   <imgdir name="2022071">
     <string name="name" value="Korean Warrior"/>
@@ -666,23 +666,23 @@
   </imgdir>
   <imgdir name="2022074">
     <string name="name" value="Oolleung Squid"/>
-    <string name="desc" value="Dried squid from Oolleung renowned for its taste. \nRecovers 500 HP &amp; MP."/>
+    <string name="desc" value="Dried squid from Oolleung renowned for its taste.\nRecovers 500 HP &amp; MP."/>
   </imgdir>
   <imgdir name="2022075">
     <string name="name" value="Mini Coke"/>
-    <string name="desc" value="A sweet, tasty, carbonated Coke featured in a Mini Can. nAttack +8, Magic Attack +8 for 20 minutes."/>
+    <string name="desc" value="A sweet, tasty, carbonated Coke featured in a Mini Can.\nAttack +8, Magic Attack +8 for 20 minutes."/>
   </imgdir>
   <imgdir name="2022076">
     <string name="name" value="Coke Pill"/>
-    <string name="desc" value="A pill made out of a sweet, tasty, carbonated Coke. nAttack +10, Magic Attack +10, Defense +10 for 15 minutes."/>
+    <string name="desc" value="A pill made out of a sweet, tasty, carbonated Coke.\nAttack +10, Magic Attack +10, Defense +10 for 15 minutes."/>
   </imgdir>
   <imgdir name="2022077">
     <string name="name" value="Coke Lite Pill"/>
-    <string name="desc" value="A pill made out of a sweet, tasty, carbonated Coke. nAttack +12, Magic Attack +12, Defense +12 for 15 minutes."/>
+    <string name="desc" value="A pill made out of a sweet, tasty, carbonated Coke.\nAttack +12, Magic Attack +12, Defense +12 for 15 minutes."/>
   </imgdir>
   <imgdir name="2022078">
     <string name="name" value="Coke Zero Pill"/>
-    <string name="desc" value="A pill made out of a sweet, tasty, carbonated Coke. nAttack +15, Magic Attack +15, Defense +15 for 15 minutes."/>
+    <string name="desc" value="A pill made out of a sweet, tasty, carbonated Coke.\nAttack +15, Magic Attack +15, Defense +15 for 15 minutes."/>
   </imgdir>
   <imgdir name="2022079">
     <string name="name" value="Barbecue"/>
@@ -722,19 +722,19 @@
   </imgdir>
   <imgdir name="2022094">
     <string name="name" value="Chicken Soup"/>
-    <string name="desc" value="Weapon Attack+20, Magic Attack +30 for 15 minutes."/>
+    <string name="desc" value="Weapon Attack +20, Magic Attack +30 for 15 minutes."/>
   </imgdir>
   <imgdir name="2022096">
     <string name="name" value="Fried Chicken"/>
-    <string name="desc" value="Crispy on the outside, soft on the inside. \nRecovers HP 400."/>
+    <string name="desc" value="Crispy on the outside, soft on the inside.\nRecovers HP 400."/>
   </imgdir>
   <imgdir name="2022097">
     <string name="name" value="Chun Gwon"/>
-    <string name="desc" value="A dish full of renowned Chun Gwon. nnRecovers MP 400."/>
+    <string name="desc" value="A dish full of renowned Chun Gwon.\nRecovers MP 400."/>
   </imgdir>
   <imgdir name="2022098">
     <string name="name" value="Bubble Gum"/>
-    <string name="desc" value="A fruity bubble gum that can make a huge bubble.n Jump +5 for 20 minutes."/>
+    <string name="desc" value="A fruity bubble gum that can make a huge bubble.\nJump +5 for 20 minutes."/>
   </imgdir>
   <imgdir name="2022099">
     <string name="name" value="HP up"/>
@@ -754,19 +754,19 @@
   </imgdir>
   <imgdir name="2022103">
     <string name="name" value="Thai Cookie"/>
-    <string name="desc" value="A sweet, Thai treat. \nRecovers HP 150."/>
+    <string name="desc" value="A sweet, Thai treat.\nRecovers HP 150."/>
   </imgdir>
   <imgdir name="2022105">
     <string name="name" value="Green Malady&apos;s Candy"/>
-    <string name="desc" value="A magical concoction bewitched for wellness by Malady. \nRecovers 50% of the HP. Also recovers 50% of MP."/>
+    <string name="desc" value="A magical concoction bewitched for wellness by Malady.\nRecovers 50% of the HP. Also recovers 50% of MP."/>
   </imgdir>
   <imgdir name="2022106">
     <string name="name" value="Red Malady&apos;s Candy"/>
-    <string name="desc" value="An enticing piece of candy straight from Malady&apos;s finest pot. \nRecovers around 300 MP."/>
+    <string name="desc" value="An enticing piece of candy straight from Malady&apos;s finest pot.\nRecovers around 300 MP."/>
   </imgdir>
   <imgdir name="2022107">
     <string name="name" value="Blue Malady&apos;s Candy"/>
-    <string name="desc" value="This delicious candy holds a special blessing from Malady. \nRecovers all HP and MP."/>
+    <string name="desc" value="This delicious candy holds a special blessing from Malady.\nRecovers all HP and MP."/>
   </imgdir>
   <imgdir name="2022108">
     <string name="name" value="Horntail Squad : Victory"/>
@@ -782,7 +782,7 @@
   </imgdir>
   <imgdir name="2022113">
     <string name="name" value="Pumpkin Pie"/>
-    <string name="desc" value="A piping hot, delicious pie right from Grandma Benson&apos;s oven. Eat up! \nRecovers 700 HP, 400 MP and Defense +50 for 10 mins."/>
+    <string name="desc" value="A piping hot, delicious pie right from Grandma Benson&apos;s oven. Eat up!\nRecovers 700 HP, 400 MP, Weapon def. +50 for 10 minutes."/>
   </imgdir>
   <imgdir name="2022116">
     <string name="name" value="Peach"/>
@@ -794,7 +794,7 @@
   </imgdir>
   <imgdir name="2022118">
     <string name="name" value="Admin&apos;s Congrats"/>
-    <string name="desc" value="A mysterious form of bless given by the administrator. Attack +10, Magic Attack +10, Defense+ 30, Accuracy +20, Avoidability +20, Speed +3 and Jump +3 for 20 minutes"/>
+    <string name="desc" value="A mysterious form of bless given by the administrator. Attack +10, Magic Attack +10, Defense+ 30, Accuracy +20, Avoidability +20, Speed +3 and Jump +3 for 20 minutes."/>
   </imgdir>
   <imgdir name="2022119">
     <string name="name" value="Tree Ornament"/>
@@ -802,15 +802,15 @@
   </imgdir>
   <imgdir name="2022120">
     <string name="name" value="Christmas Melon"/>
-    <string name="desc" value="A special melon imbued with Holiday blessings. Delicious! nRecovers 2000 HP and 1000 MP."/>
+    <string name="desc" value="A special melon imbued with Holiday blessings. Delicious!\nRecovers 2000 HP and 1000 MP."/>
   </imgdir>
   <imgdir name="2022121">
     <string name="name" value="Gelt Chocolate"/>
-    <string name="desc" value="A special piece of tasty chocolate given out at the Festival of Lights. \nRecovers 100 HP &amp; MP, and +120 Attack +120 Weapon Def. +30 Accuracy +30 Avoidability + 10 Speed +10 Jump for 10 minutes."/>
+    <string name="desc" value="A special piece of tasty chocolate given out at the Festival of Lights.\nRecovers 100 HP &amp; MP, and +120 Attack +120 Weapon Def. +30 Accuracy +30 Avoidability + 10 Speed +10 Jump for 10 minutes."/>
   </imgdir>
   <imgdir name="2022123">
     <string name="name" value="Banana Graham Pie"/>
-    <string name="desc" value="This scrumptious pie is sure to lighten your spirits! nRecovers 400 HP &amp; 500 MP, and +120 Magic +120 Magic Def. +30 Accuracy +30 Avoidability + 10 Speed +10 Jump for 10 minutes."/>
+    <string name="desc" value="This scrumptious pie is sure to lighten your spirits!\nRecovers 400 HP &amp; 500 MP, and +120 Magic +120 Magic Def. +30 Accuracy +30 Avoidability + 10 Speed +10 Jump for 10 minutes."/>
   </imgdir>
   <imgdir name="2022124">
     <string name="name" value="Magic of Kasandra"/>
@@ -838,7 +838,7 @@
   </imgdir>
   <imgdir name="2022130">
     <string name="name" value="Blossom Juice"/>
-    <string name="desc" value="A special energy drink made from crushed Cherry Blossoms and other mystic ingredients. Recovers 1200 HP, 900 MP and +12 to DEF for 20 minutes."/>
+    <string name="desc" value="A special energy drink made from crushed Cherry Blossoms and other mystic ingredients.\nRecovers 1200 HP, 900 MP, and +12 to Def. for 20 minutes."/>
   </imgdir>
   <imgdir name="2022131">
     <string name="name" value="Ginseng Concentrate"/>
@@ -866,31 +866,31 @@
   </imgdir>
   <imgdir name="2022146">
     <string name="name" value="Peach Juice"/>
-    <string name="desc" value="Peace juice made by the weird pharmacist in Mu Lung, Dr. DonRecovers around 500 MP."/>
+    <string name="desc" value="Peach juice made by the weird pharmacist in Mu Lung, Dr. Do.\nRecovers around 500 MP."/>
   </imgdir>
   <imgdir name="2022147">
     <string name="name" value="Bellflower Medicine Soup"/>
-    <string name="desc" value="A herb medicine made from bellflowers and snake.nAttack + 6 for 10 minutes."/>
+    <string name="desc" value="A herb medicine made from bellflowers and snake.\nAttack +6 for 10 minutes."/>
   </imgdir>
   <imgdir name="2022148">
     <string name="name" value="Pill of Tunnel Vision"/>
-    <string name="desc" value="A pill of acorn powder.  The marksman&apos;s liquid medicine.  Increases +12 accuracy for 10 minutes."/>
+    <string name="desc" value="A pill of acorn powder. The marksman&apos;s liquid medicine. Increases +12 Accuracy for 10 minutes."/>
   </imgdir>
   <imgdir name="2022149">
     <string name="name" value="Pill of Intelligence"/>
-    <string name="desc" value="A pill of powdered deer antler and wild ginseng.  Increases Magic Attack by +10 for 10 minutes."/>
+    <string name="desc" value="A pill of powdered deer antler and wild ginseng. Increases Magic Attack by +10 for 10 minutes."/>
   </imgdir>
   <imgdir name="2022150">
     <string name="name" value="Slithering Balm"/>
-    <string name="desc" value="Ointment medicine made from Mr. Alli&apos;s skin.  Gives +12 Avoidability for 10 minutes."/>
+    <string name="desc" value="Ointment medicine made from Mr. Alli&apos;s skin. Gives +12 Avoidability for 10 minutes."/>
   </imgdir>
   <imgdir name="2022151">
     <string name="name" value="Cassandra&apos;s Magic"/>
-    <string name="desc" value="A mysterious spell cast by Cassandra.  Gives +20 Att and Magic, +100 Defense, +50 accuracy and avoidability, and +10 speed and jump for 1 hour."/>
+    <string name="desc" value="A mysterious spell cast by Cassandra. Gives +20 Att and Magic, +100 Defense, +50 accuracy and avoidability, and +10 speed and jump for 1 hour."/>
   </imgdir>
   <imgdir name="2022152">
     <string name="name" value="Cassandra&apos;s Magic"/>
-    <string name="desc" value="A mysterious spell cast by Cassandra.  Gives +10 Att and Magic, +30 Defense, +20 accuracy and avoidability, and +3 speed and jump for 20 minutes."/>
+    <string name="desc" value="A mysterious spell cast by Cassandra. Gives +10 Att and Magic, +30 Defense, +20 accuracy and avoidability, and +3 speed and jump for 20 minutes."/>
   </imgdir>
   <imgdir name="2022153">
     <string name="name" value="Happy birthday"/>
@@ -902,7 +902,7 @@
   </imgdir>
   <imgdir name="2022155">
     <string name="name" value="Desert Mist"/>
-    <string name="desc" value="Pure water extracted from Katuse roots.  Recovers 200 MP."/>
+    <string name="desc" value="Pure water extracted from Katuse roots. Recovers 200 MP."/>
   </imgdir>
   <imgdir name="2022156">
     <string name="name" value="Black Bean Noodle"/>
@@ -938,7 +938,7 @@
   </imgdir>
   <imgdir name="2022174">
     <string name="name" value="White Potion"/>
-    <string name="desc" value="A highly-concentrated potion made out of red herbs.\nRecovers 300 HP."/>
+    <string name="desc" value="A highly concentrated potion made out of red herbs.\nRecovers 300 HP."/>
   </imgdir>
   <imgdir name="2022179">
     <string name="name" value="Onyx Apple"/>
@@ -962,7 +962,7 @@
   </imgdir>
   <imgdir name="2022184">
     <string name="name" value="Maple BBQ"/>
-    <string name="desc" value="Delicious, succulent BBQ meat. Take a big bite--you know you want to.  Weapon attack +13, Magic Attack +13 for 20 min."/>
+    <string name="desc" value="Delicious, succulent BBQ meat. Take a big bite--you know you want to. Weapon Attack +13, Magic Attack +13 for 20 min."/>
   </imgdir>
   <imgdir name="2022185">
     <string name="name" value="Fireworks"/>
@@ -970,11 +970,11 @@
   </imgdir>
   <imgdir name="2022186">
     <string name="name" value="Soft White Bun"/>
-    <string name="desc" value="Freshly baked bread, hot from the oven!  Makes you warm inside and prevents HP loss for 30 minutes in the El Nath region."/>
+    <string name="desc" value="Freshly baked bread, hot from the oven! Makes you warm inside and prevents HP loss for 30 minutes in the El Nath region."/>
   </imgdir>
   <imgdir name="2022187">
     <string name="name" value="Cassandra&apos;s Magic"/>
-    <string name="desc" value="Breathe comfortably underwater for 30 minutes with Cassandra&apos;s magic.  Prevents the constant HP damage you receive for every 10 seconds underwater."/>
+    <string name="desc" value="Breathe comfortably underwater for 30 minutes with Cassandra&apos;s magic. Prevents the constant HP damage you receive for every 10 seconds underwater."/>
   </imgdir>
   <imgdir name="2022189">
     <string name="name" value="Grilled Cheese"/>
@@ -1006,15 +1006,15 @@
   </imgdir>
   <imgdir name="2022196">
     <string name="name" value="Wedding Bouquet"/>
-    <string name="desc" value="A special wedding bouquet.  Gives +5 Weapon Attack and +3 Magic Attack for 5 minutes."/>
+    <string name="desc" value="A special wedding bouquet. Gives +5 Weapon Attack and +3 Magic Attack for 5 minutes."/>
   </imgdir>
   <imgdir name="2022197">
     <string name="name" value="Wedding Bouquet"/>
-    <string name="desc" value="A special wedding bouquet.  Gives +8 Weapon Attack and +5 Magic Attack for 5 minutes."/>
+    <string name="desc" value="A special wedding bouquet. Gives +8 Weapon Attack and +5 Magic Attack for 5 minutes."/>
   </imgdir>
   <imgdir name="2022198">
     <string name="name" value="Russellon&apos;s Pills"/>
-    <string name="desc" value="A pill made by Russellon from Magatia.  The actual effects of this pill remain a mystery..."/>
+    <string name="desc" value="A pill made by Russellon from Magatia. The actual effects of this pill remain a mystery..."/>
   </imgdir>
   <imgdir name="2022199">
     <string name="name" value="Russellon&apos;s Potion"/>
@@ -1022,19 +1022,19 @@
   </imgdir>
   <imgdir name="2022200">
     <string name="name" value="Wedding Bouquet"/>
-    <string name="desc" value="A special wedding bouquet.  Gives +10 Weapon Attack and +8 Magic Attack for 5 minutes."/>
+    <string name="desc" value="A special wedding bouquet. Gives +10 Weapon Attack and +8 Magic Attack for 5 minutes."/>
   </imgdir>
   <imgdir name="2022203">
     <string name="name" value="Laksa"/>
-    <string name="desc" value="Singapore local speciality spicy noodle. It triggers one to sweat after consumpsion.\nRecovers 800 HP."/>
+    <string name="desc" value="Singapore local speciality spicy noodle. It triggers one to sweat after consuming it.\nRecovers 800 HP."/>
   </imgdir>
   <imgdir name="2022204">
     <string name="name" value="Hokkien Mee"/>
-    <string name="desc" value="Singapore&apos;s local speciality prawn noodles. It is normally served with prawns, chili &amp; lime. \nRecovers 1200 HP."/>
+    <string name="desc" value="Singapore&apos;s local speciality prawn noodles. It is normally served with prawns, chili &amp; lime.\nRecovers 1200 HP."/>
   </imgdir>
   <imgdir name="2022205">
     <string name="name" value="Carrot Cake"/>
-    <string name="desc" value="A delicious local traditional food. It is made up of carrot extracts &amp; secret recipes. \nRecovers 1800 HP."/>
+    <string name="desc" value="A delicious local traditional food. It is made up of carrot extracts &amp; secret recipes.\nRecovers 1800 HP."/>
   </imgdir>
   <imgdir name="2022206">
     <string name="name" value="Chicken Rice"/>
@@ -1050,31 +1050,31 @@
   </imgdir>
   <imgdir name="2022209">
     <string name="name" value="Rambutan"/>
-    <string name="desc" value="A fruit that is delicious &amp; juicy. It is so sweet that it attracts ants if they are not well attended to. \nRecovers 800 MP"/>
+    <string name="desc" value="A fruit that is delicious &amp; juicy. It is so sweet that it attracts ants if they are not well attended to.\nRecovers 800 MP"/>
   </imgdir>
   <imgdir name="2022210">
     <string name="name" value="Dragon Fruit"/>
-    <string name="desc" value="Another fruit that is delicious &amp; juicy, similar to Rambutan, it will attract unwanted pests if they are not attended. \nRecovers 1600 MP."/>
+    <string name="desc" value="Another fruit that is delicious &amp; juicy, similar to Rambutan, it will attract unwanted pests if they are not attended.\nRecovers 1600 MP."/>
   </imgdir>
   <imgdir name="2022211">
     <string name="name" value="Durian"/>
-    <string name="desc" value="The fruit is nominated as the King of Fruits around the region. Despite having a hard &amp; thorny shell, the fruit that lies within is extremely fragrant, and it tastes great! nRecovers 3200 MP."/>
+    <string name="desc" value="The fruit is nominated as the King of Fruits around the region. Despite having a hard &amp; thorny shell, the fruit that lies within is extremely fragrant, and it tastes great!\nRecovers 3200 MP."/>
   </imgdir>
   <imgdir name="2022212">
     <string name="name" value="Nasi Lemak"/>
-    <string name="desc" value="A popular Malay Traditional Dish mainly made up of rice, egg &amp; cucumber, soaked with pandan fragrant.nImproves Magic Attack +8 for 5 minutes."/>
+    <string name="desc" value="A popular Malay Traditional Dish mainly made up of rice, egg &amp; cucumber, soaked with pandan fragrant.\nImproves Magic Attack +8 for 5 minutes."/>
   </imgdir>
   <imgdir name="2022213">
     <string name="name" value="Roti Prata"/>
-    <string name="desc" value="A popular Indian Traditional Dish made up of flour. It is normally served with sugar &amp; curry sauces.n Improves Magic Attack +8 for 10 Minutes."/>
+    <string name="desc" value="A popular Indian Traditional Dish made up of flour. It is normally served with sugar &amp; curry sauces.\nImproves Magic Attack +8 for 10 Minutes."/>
   </imgdir>
   <imgdir name="2022214">
     <string name="name" value="Pepper Crab"/>
-    <string name="desc" value="A popular Chinese traditional dish made of up fresh steam crab, pepper, egg &amp; secret recipes.nImproves Weapon Attack +8 for 5 minutes."/>
+    <string name="desc" value="A popular Chinese traditional dish made of up fresh steam crab, pepper, egg &amp; secret recipes.\nImproves Weapon Attack +8 for 5 minutes."/>
   </imgdir>
   <imgdir name="2022215">
     <string name="name" value="Chili Crab"/>
-    <string name="desc" value="A popular Chinese traditional dish made of up fresh steam crab, chili power, egg &amp; secret recipes.nImproves Weapon Attack +8 for 10 minutes."/>
+    <string name="desc" value="A popular Chinese traditional dish made of up fresh steam crab, chili power, egg &amp; secret recipes.\nImproves Weapon Attack +8 for 10 minutes."/>
   </imgdir>
   <imgdir name="2022224">
     <string name="name" value="Russellon&apos;s Potion"/>
@@ -1110,7 +1110,7 @@
   </imgdir>
   <imgdir name="2022242">
     <string name="name" value="Edmund&apos;s Special Brew"/>
-    <string name="desc" value="A healing tonic made with Edmund&apos;s secret recipe.  Just the thing when you&apos;re feeling under the weather!  [Restores 50% of HP and MP, also gives +14 W. Att + 30 M.Att, for 10 minutes.]"/>
+    <string name="desc" value="A healing tonic made with Edmund&apos;s secret recipe. Just the thing when you&apos;re feeling under the weather! [Restores 50% of HP and MP, also gives +14 W. Att + 30 M.Att, for 10 minutes.]"/>
   </imgdir>
   <imgdir name="2022243">
     <string name="name" value="Sophilia&apos;s Necklace"/>
@@ -1119,33 +1119,33 @@
   </imgdir>
   <imgdir name="2022244">
     <string name="name" value="Smore"/>
-    <string name="desc" value="A tasty, hot smore. Perfect for a toasty Halloween night!"/>
+    <string name="desc" value="A tasty, hot smore. Perfect for a toasty Halloween night!\n[Restores 25% HP/MP and gives a boost of +10 to Avoidability, Jump and Speed for 10 minutes.]"/>
     <null name="[Restores 25% HP/MP and gives a boost of +10 to Avoidability, Jump and Speed for 10 minutes.]"/>
   </imgdir>
   <imgdir name="2022245">
     <string name="name" value="Heartstopper"/>
-    <string name="desc" value="Just one taste of this spicy candy and it&apos;ll feel like your heart&apos;s on fire!"/>
+    <string name="desc" value="Just one taste of this spicy candy and it&apos;ll feel like your heart&apos;s on fire!\n[Gives +60 Weapon Attack, +60 Speed, +60 Avoidability for 1 minute]"/>
     <null name="[Gives +60 Weapon Attack, +60 Speed, +60 Avoidability for 1 minute]"/>
   </imgdir>
   <imgdir name="2022246">
     <string name="name" value="Pumpkin Taffy"/>
-    <string name="desc" value="Sweetened pumpkin taffy on a candy cane stick.  [Gives +15 Weapon Defense, +15 Magic Defense for 5 minutes]"/>
+    <string name="desc" value="Sweetened pumpkin taffy on a candy cane stick. [Gives +15 Weapon Defense, +15 Magic Defense for 5 minutes]"/>
   </imgdir>
   <imgdir name="2022247">
     <string name="name" value="Red Gummy Slime"/>
-    <string name="desc" value="Super-chewy gummy slimes. This one is cherry-flavored.  If only real Slimes tasted this good. [Restore 1200HP, 1200MP]"/>
+    <string name="desc" value="Super-chewy gummy slimes. This one is cherry-flavored. If only real Slimes tasted this good. [Restores 1200 HP, 1200 MP]"/>
   </imgdir>
   <imgdir name="2022248">
     <string name="name" value="Green Gummy Slime"/>
-    <string name="desc" value="Super-chewy gummy slimes. This one is lime-flavored.  If only real Slimes tasted this good. [Restores 600 HP]"/>
+    <string name="desc" value="Super-chewy gummy slimes. This one is lime-flavored. If only real Slimes tasted this good. [Restores 600 HP]"/>
   </imgdir>
   <imgdir name="2022249">
     <string name="name" value="Purple Gummy Slime"/>
-    <string name="desc" value="Super-chewy gummy slimes. This one is grape-flavored.  If only real Slimes tasted this good. [Restores 600 MP]"/>
+    <string name="desc" value="Super-chewy gummy slimes. This one is grape-flavored. If only real Slimes tasted this good. [Restores 600 MP]"/>
   </imgdir>
   <imgdir name="2022250">
     <string name="name" value="Orange Gummy Slime"/>
-    <string name="desc" value="Super-chewy gummy slimes. This one is orange-flavored.  If only real Slimes tasted this good. [Restores 600HP, 600MP]"/>
+    <string name="desc" value="Super-chewy gummy slimes. This one is orange-flavored. If only real Slimes tasted this good. [Restores 600 HP, 600 MP]"/>
   </imgdir>
   <imgdir name="2022251">
     <string name="name" value="Maple Pop"/>
@@ -1161,7 +1161,7 @@
   </imgdir>
   <imgdir name="2022255">
     <string name="name" value="Pumpkin Pieces"/>
-    <string name="desc" value="Pieces of pumpkin left over from making halloween Jack-o&apos;-Lanterns. The pumpkin, perfectly ripe, has an aroma that is sweeter than ever. Each piece recovers 50 HP and 50 MP."/>
+    <string name="desc" value="Pieces of pumpkin left over from making Halloween Jack-o&apos;-Lanterns. The pumpkin, perfectly ripe, has an aroma that is sweeter than ever. Each piece recovers 50 HP and 50 MP."/>
   </imgdir>
   <imgdir name="2022256">
     <string name="name" value="Halloween Candy"/>
@@ -1185,19 +1185,19 @@
   </imgdir>
   <imgdir name="2022261">
     <string name="name" value="Stuffing Scoop"/>
-    <string name="desc" value="A delicious scoop of stuffing. This treat comes around only once in a while so eat it up before it gets cold. \n[Restores 600 HP/ 600 MP]"/>
+    <string name="desc" value="A delicious scoop of stuffing. This treat comes around only once in a while so eat it up before it gets cold.\n[Restores 600 HP/ 600 MP]"/>
   </imgdir>
   <imgdir name="2022262">
     <string name="name" value="Cranberry Sauce"/>
-    <string name="desc" value="This delicious cranberry sauce complements almost any meal! \n[Gives + 30 Magic Attack for 3 minutes]"/>
+    <string name="desc" value="This delicious cranberry sauce complements almost any meal!\n[Gives + 30 Magic Attack for 3 minutes]"/>
   </imgdir>
   <imgdir name="2022263">
     <string name="name" value="Mashed Potato"/>
-    <string name="desc" value="It looks like someone dropped this potato. \n[Restores 800 HP]"/>
+    <string name="desc" value="It looks like someone dropped this potato.\n[Restores 800 HP]"/>
   </imgdir>
   <imgdir name="2022264">
     <string name="name" value="Gravy"/>
-    <string name="desc" value="The only thing better than a gravy boat is a gravy train. \n[Restores 800 MP]"/>
+    <string name="desc" value="The only thing better than a gravy boat is a gravy train.\n[Restores 800 MP]"/>
   </imgdir>
   <imgdir name="2022265">
     <string name="name" value="Snowing Fishbread"/>
@@ -1221,31 +1221,31 @@
   </imgdir>
   <imgdir name="2022271">
     <string name="name" value="Maplemas Ham"/>
-    <string name="desc" value="A delicious looking Christmas Ham with a sprig of mistletoe on top.\nRecovers 3000 HP and MP."/>
+    <string name="desc" value="A delicious-looking Christmas Ham with a sprig of mistletoe on top.\nRecovers 3000 HP and MP."/>
   </imgdir>
   <imgdir name="2022272">
     <string name="name" value="Smoken Salmon"/>
-    <string name="desc" value="The traditional Versalmas dinner.  Smells... like fish. \nRecovers 2385 HP and 3791 MP."/>
+    <string name="desc" value="The traditional Versalmas dinner. Smells... like fish.\nRecovers 2385 HP and 3791 MP."/>
   </imgdir>
   <imgdir name="2022273">
     <string name="name" value="Ssiws Cheese"/>
-    <string name="desc" value="Cheese from the alternate dimension of Versal.  Looks funny but smells quite nice.  nGives +220 Magic Attack for 2 minutes"/>
+    <string name="desc" value="Cheese from the alternate dimension of Versal. Looks funny but smells quite nice.\nGives +220 Magic Attack for 2 minutes"/>
   </imgdir>
   <imgdir name="2022274">
     <string name="name" value="Sugar-Coated Olives"/>
-    <string name="desc" value="Olives frosted with pink sugar -- a special treat beloved by children from Versal! nGives +40 Speed and + 25 Jump for 5 minutes."/>
+    <string name="desc" value="Olives frosted with pink sugar -- a special treat beloved by children from Versal!\nGives +40 Speed and +25 Jump for 5 minutes."/>
   </imgdir>
   <imgdir name="2022275">
     <string name="name" value="Caramel Onion"/>
-    <string name="desc" value="O-Pongo&apos;s favorite treat!  Creamy caramel with a crunchy onion center! nRestores 800 HP and MP."/>
+    <string name="desc" value="O-Pongo&apos;s favorite treat! Creamy caramel with a crunchy onion center!\nRestores 800 HP and MP."/>
   </imgdir>
   <imgdir name="2022276">
     <string name="name" value="Chocolate Wafers"/>
-    <string name="desc" value="A crispy wafer layered with chocolate creme. nGives +40 Weapon Attack for 3 minutes"/>
+    <string name="desc" value="A crispy wafer layered with chocolate creme.\nGives +40 Weapon Attack for 3 minutes"/>
   </imgdir>
   <imgdir name="2022277">
     <string name="name" value="Sunblock"/>
-    <string name="desc" value="SPF 1000.  Blocks all harmful rays, including magical ones. nGives +200 Magic Defense for 10 minutes."/>
+    <string name="desc" value="SPF 1000. Blocks all harmful rays, including magical ones.\nGives +200 Magic Defense for 10 minutes."/>
   </imgdir>
   <imgdir name="2022278">
     <string name="name" value="Lump of Coal"/>
@@ -1265,15 +1265,15 @@
   </imgdir>
   <imgdir name="2022282">
     <string name="name" value="Naricain&apos;s Demon Elixir"/>
-    <string name="desc" value="A fiery black liquid that gives the user the power of a thousand demons when consumed. [Gives +140 Weapon Attack for 8 minutes]"/>
+    <string name="desc" value="A fiery black liquid that gives the user the power of a thousand demons when consumed.\n[Gives +140 Weapon Attack for 8 minutes]"/>
   </imgdir>
   <imgdir name="2022283">
     <string name="name" value="Subani&apos;s Mystic Cauldron"/>
-    <string name="desc" value="Drinking the swirling blue liquid within this small iron pot fills the user with an energy that emanates a protective aura. [Gives +100 Overall Defense, +200 Magic Attack for 10 minutes]"/>
+    <string name="desc" value="Drinking the swirling blue liquid within this small iron pot fills the user with an energy that emanates a protective aura.\n[Gives +100 Overall Defense, +200 Magic Attack for 10 minutes]"/>
   </imgdir>
   <imgdir name="2022284">
     <string name="name" value="Barricade Booster"/>
-    <string name="desc" value="John Barricade&apos;s special concoction, used to get him out of tight jams.  For use in emergencies!  [Gives +50 Avoidability, +50 Accuracy, +10 Jump for 5 minutes]"/>
+    <string name="desc" value="John Barricade&apos;s special concoction, used to get him out of tight jams. For use in emergencies!\n[Gives +50 Avoidability, +50 Accuracy, +10 Jump for 5 minutes]"/>
   </imgdir>
   <imgdir name="2022285">
     <string name="name" value="Sweet Heart"/>
@@ -1293,15 +1293,15 @@
   </imgdir>
   <imgdir name="2022306">
     <string name="name" value="Primal Brew"/>
-    <string name="desc" value="A mixture made from an ancient Taru shaman recipe.  Instills warriors with the primal strength of the Jungle Spirit. [Gives +35 Weapon Attack, +10 Accuracy for 20 minutes.]"/>
+    <string name="desc" value="A mixture made from an ancient Taru shaman recipe. Instills warriors with the primal strength of the Jungle Spirit.\n[Gives +35 Weapon Attack, +10 Accuracy for 20 minutes.]"/>
   </imgdir>
   <imgdir name="2022307">
     <string name="name" value="Spirit Herbs"/>
-    <string name="desc" value="Special incense used by ancient Taru shamans for communion rituals with the Jungle Spirit. [Gives +90 Magic Attack for 20 minutes.]"/>
+    <string name="desc" value="Special incense used by ancient Taru shamans for communion rituals with the Jungle Spirit.\n[Gives +90 Magic Attack for 20 minutes.]"/>
   </imgdir>
   <imgdir name="2022308">
     <string name="name" value="Jungle Juice"/>
-    <string name="desc" value="A delicious natural beverage made from a secret blend of jungle fruits, flowers, roots, and vines. The perfect thing to fuel a Taru brave through a long jungle trek!  [Restores 1000 HP and 2000 MP.]"/>
+    <string name="desc" value="A delicious natural beverage made from a secret blend of jungle fruits, flowers, roots, and vines. The perfect thing to fuel a Taru brave through a long jungle trek!\n[Restores 1000 HP and 2000 MP.]"/>
   </imgdir>
   <imgdir name="2022309">
     <string name="name" value="Treasure Hunt Note"/>
@@ -1309,7 +1309,7 @@
   </imgdir>
   <imgdir name="2022310">
     <string name="name" value="Chocolate Cream Cupcake"/>
-    <string name="desc" value="A delicious chocolate cupcake with vanilla cream filling. One taste and you&apos;ll be hooked!  [Restores 300 HP &amp; MP, and gives +30 Accuracy, +30 Speed, and +30 Jump for 3 minutes.]"/>
+    <string name="desc" value="A delicious chocolate cupcake with vanilla cream filling. One taste and you&apos;ll be hooked! [Restores 300 HP &amp; MP, and gives +30 Accuracy, +30 Speed, and +30 Jump for 3 minutes.]"/>
   </imgdir>
   <imgdir name="2022311">
     <string name="name" value="Big Cream Puff"/>
@@ -1317,11 +1317,11 @@
   </imgdir>
   <imgdir name="2022332">
     <string name="name" value="Agent O&apos;s Encouragement"/>
-    <string name="desc" value="An encouraging message from Agent O.  Jump rate will be increased by 20 for 30 minutes."/>
+    <string name="desc" value="An encouraging message from Agent O. Jump rate will be increased by 20 for 30 minutes."/>
   </imgdir>
   <imgdir name="2022333">
     <string name="name" value="Agent O&apos;s Encouragement"/>
-    <string name="desc" value="An encouraging message from Agent O.  Speed will be increased by 40 for 30 minutes."/>
+    <string name="desc" value="An encouraging message from Agent O. Speed will be increased by 40 for 30 minutes."/>
   </imgdir>
   <imgdir name="2022335">
     <string name="name" value="Baby Chick Cookie"/>
@@ -1337,31 +1337,31 @@
   </imgdir>
   <imgdir name="2022338">
     <string name="name" value="VitroJuice"/>
-    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337.  Looks suspiciously like an energy drink.  Drink at your own risk! [Gives +14 Weapon Attack for 15 minutes]"/>
+    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337. Looks suspiciously like an energy drink. Drink at your own risk! [Gives +14 Weapon Attack for 15 minutes]"/>
   </imgdir>
   <imgdir name="2022339">
     <string name="name" value="NitroJuice"/>
-    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337.  Looks suspiciously like an energy drink.  Drink at your own risk! [Gives +22 Weapon Attack for 10 minutes]"/>
+    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337. Looks suspiciously like an energy drink. Drink at your own risk! [Gives +22 Weapon Attack for 10 minutes]"/>
   </imgdir>
   <imgdir name="2022340">
     <string name="name" value="BlastroJuice"/>
-    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337.  Looks suspiciously like an energy drink.  Drink at your own risk! [Gives +90 Weapon Attack for 1 minute]"/>
+    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337. Looks suspiciously like an energy drink. Drink at your own risk! [Gives +90 Weapon Attack for 1 minute]"/>
   </imgdir>
   <imgdir name="2022341">
     <string name="name" value="ElectroJuice"/>
-    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337.  Looks suspiciously like an energy drink, but drink at your own risk! [Gives +50 Magic Attack for 10 minutes.]"/>
+    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337. Looks suspiciously like an energy drink, but drink at your own risk! [Gives +50 Magic Attack for 10 minutes.]"/>
   </imgdir>
   <imgdir name="2022342">
     <string name="name" value="MegaJuice"/>
-    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337.  Looks suspiciously like an energy drink, but drink at your own risk! [Gives +200 Magic Attack for 30 seconds.]"/>
+    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337. Looks suspiciously like an energy drink, but drink at your own risk! [Gives +200 Magic Attack for 30 seconds.]"/>
   </imgdir>
   <imgdir name="2022343">
     <string name="name" value="GigaJuice"/>
-    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337.  Tasty and strong enough to dissolve rust from machinery!  Drink at your own risk! [Gives +700 Magic Attack for 10 seconds.]"/>
+    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337. Tasty and strong enough to dissolve rust from machinery! Drink at your own risk! [Gives +700 Magic Attack for 10 seconds.]"/>
   </imgdir>
   <imgdir name="2022344">
     <string name="name" value="JigaJuice"/>
-    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337.  Drink at your own risk!   Gives the user a sudden jolting surge of energy, so use it or lose it! [Gives +1000 Magic Attack for 5 seconds.]"/>
+    <string name="desc" value="A futuristic power pack full of liquid fuel synthesized by T-1337. Drink at your own risk! Gives the user a sudden jolting surge of energy, so use it or lose it! [Gives +1000 Magic Attack for 5 seconds.]"/>
   </imgdir>
   <imgdir name="2022345">
     <string name="name" value="The Energizer Drink"/>
@@ -1433,7 +1433,7 @@
   </imgdir>
   <imgdir name="2022454">
     <string name="name" value="Cygnus&apos;s Blessing"/>
-    <string name="desc" value="Once I completed Cygnus&apos; Book, the spirit&apos;s power covered me and blessed me.  It increased my Attack Rate by 10, Physical Defense Rate by 80 and  Speed by 5 for 10 minutes."/>
+    <string name="desc" value="Once I completed Cygnus&apos; Book, the spirit&apos;s power covered me and blessed me. It increased my Attack Rate by 10, Physical Defense Rate by 80 and Speed by 5 for 10 minutes."/>
   </imgdir>
   <imgdir name="2022538">
     <string name="name" value="Red Easter Egg"/>
@@ -1441,35 +1441,35 @@
   </imgdir>
   <imgdir name="2030000">
     <string name="name" value="Return Scroll - Nearest Town"/>
-    <string name="desc" value="Returns you to the nearest town."/>
+    <string name="desc" value="Returns you to the closest town from where you are. Once used, it disappears."/>
   </imgdir>
   <imgdir name="2030001">
     <string name="name" value="Return Scroll to Lith Harbor"/>
-    <string name="desc" value="Returns you to Lith Harbor."/>
+    <string name="desc" value="Returns you to Lith Harbor. It disappears once it's used."/>
   </imgdir>
   <imgdir name="2030002">
     <string name="name" value="Return Scroll to Ellinia"/>
-    <string name="desc" value="Returns you to Ellinia."/>
+    <string name="desc" value="Returns you to Ellinia. It disappears once it's used."/>
   </imgdir>
   <imgdir name="2030003">
     <string name="name" value="Return Scroll to Perion"/>
-    <string name="desc" value="Returns you to Perion."/>
+    <string name="desc" value="Returns you to Perion. It disappears once it's used."/>
   </imgdir>
   <imgdir name="2030004">
     <string name="name" value="Return Scroll to Henesys"/>
-    <string name="desc" value="Returns you to Henesys."/>
+    <string name="desc" value="Returns you to Henesys, the peaceful town. It disappears once it's used."/>
   </imgdir>
   <imgdir name="2030005">
     <string name="name" value="Return Scroll to Kerning City"/>
-    <string name="desc" value="Returns you to the dark Kerning City."/>
+    <string name="desc" value="Returns you to the dark Kerning City. It disappears once it's used."/>
   </imgdir>
   <imgdir name="2030006">
     <string name="name" value="Return Scroll to Sleepywood"/>
-    <string name="desc" value="Returns you to Sleepywood, a quiet and dark forest-town."/>
+    <string name="desc" value="Returns you to Sleepywood, a quiet and dark forest-town. It disappears once it's used."/>
   </imgdir>
   <imgdir name="2030007">
     <string name="name" value="Return Scroll to Dead Mine"/>
-    <string name="desc" value="Returns you to the dead mine at the higher ground of El Nath.nCan only be used in Orbis and El Nath."/>
+    <string name="desc" value="Returns you to the dead mine at the higher ground of El Nath. It disappears once it's used.\nCan only be used in Orbis and El Nath."/>
   </imgdir>
   <imgdir name="2030008">
     <string name="name" value="Coffee Milk"/>
@@ -1493,11 +1493,11 @@
   </imgdir>
   <imgdir name="2030016">
     <string name="name" value="Phyllia&apos;s Warp Powder"/>
-    <string name="desc" value="Warp powder made by fairy Phyllia.  Teleports you to Magatia when used inside the Nihal desert region."/>
+    <string name="desc" value="Warp powder made by fairy Phyllia. Teleports you to Magatia when used inside the Nihal desert region."/>
   </imgdir>
   <imgdir name="2030019">
     <string name="name" value="Return Scroll to Nautilus"/>
-    <string name="desc" value="This scroll enables you to return to the Pirate village, Nautilus. This is a one use item and will disappear after use."/>
+    <string name="desc" value="This scroll enables you to return to the Pirate village, Nautilus. This is a one-use item and will disappear after use."/>
   </imgdir>
   <imgdir name="2030100">
     <string name="name" value="Return Scroll - Banished Area"/>
@@ -1513,279 +1513,279 @@
   </imgdir>
   <imgdir name="2040000">
     <string name="name" value="Scroll for Helmet for DEF"/>
-    <string name="desc" value="Improves the helmet&apos;s weapon def.\nSuccess rate:100%, weapon def. +1"/>
+    <string name="desc" value="Improves DEF on headwear.\nSuccess rate:100%, weapon def.+1"/>
   </imgdir>
   <imgdir name="2040001">
     <string name="name" value="Scroll for Helmet for DEF"/>
-    <string name="desc" value="Improves helmet def.\nSuccess rate:60%, weapon def.+2, magic def., +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on headwear.\nSuccess rate:60%, weapon def.+2, magic def.+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040002">
     <string name="name" value="Scroll for Helmet for DEF"/>
-    <string name="desc" value="Improves helmet def.\nSuccess Rate:10%, weapon def.+5, magic def.+3, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on headwear.\nSuccess rate:10%, weapon def.+5, magic def.+3, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040003">
     <string name="name" value="Scroll for Helmet for HP"/>
-    <string name="desc" value="Improves MaxHP on hats.\nSuccess rate:100%, MaxHP+5"/>
+    <string name="desc" value="Improves MaxHP on headwear.\nSuccess rate:100%, MaxHP+5"/>
   </imgdir>
   <imgdir name="2040004">
     <string name="name" value="Scroll for Helmet for HP"/>
-    <string name="desc" value="Improves MaxHP on hats.\nSuccess rate:60%, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on headwear.\nSuccess rate:60%, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040005">
     <string name="name" value="Scroll for Helmet for HP"/>
-    <string name="desc" value="Improves MaxHP on hats.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on headwear.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040006">
     <string name="name" value="Scroll for Helmet for DEF"/>
-    <string name="desc" value="Improves helmet def.\nSuccess rate:100%, weapon def.+5, magic def.+3, accuracy+1"/>
+    <string name="desc" value="Improves DEF on headwear.\nSuccess rate:100%, weapon def.+5, magic def.+3, accuracy+1"/>
   </imgdir>
   <imgdir name="2040007">
     <string name="name" value="Scroll for Helmet for HP"/>
-    <string name="desc" value="Improves MaxHP on hats.\nSuccess rate:100%, MaxHP+30"/>
+    <string name="desc" value="Improves MaxHP on headwear.\nSuccess rate:100%, MaxHP+30"/>
   </imgdir>
   <imgdir name="2040008">
     <string name="name" value="Dark scroll for Helmet for DEF"/>
-    <string name="desc" value="Improves helmet def.\nSuccess rate:70%, weapon def.+2, magic def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on headwear.\nSuccess rate:70%, weapon def.+2, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040009">
     <string name="name" value="Dark Scroll for Helmet for DEF"/>
-    <string name="desc" value="Improves the helmet def.\nSuccess rate:30%, weapon def.+5, magic def.+3, accuracy+1nIf failed, the item will be destroyed in a 50% rate."/>
+    <string name="desc" value="Improves DEF on headwear.\nSuccess rate:30%, weapon def.+5, magic def.+3, accuracy+1.\nIf failed, the item will be destroyed in a 50% rate."/>
   </imgdir>
   <imgdir name="2040010">
     <string name="name" value="Scroll for Helmet for HP"/>
-    <string name="desc" value="Improves MaxHP on hats.\nSuccess Rate:70%, MaxHP+10nIf failed, the item will be destroyed in a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on headwear.\nSuccess rate:70%, MaxHP+10.\nIf failed, the item will be destroyed in a 50% rate."/>
   </imgdir>
   <imgdir name="2040011">
     <string name="name" value="Dark Scroll for Helmet for HP"/>
-    <string name="desc" value="Improves MaxHP on hats.\nSuccess Rate:30%, MaxHP+30nIf failed, the item will be destroyed in a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on headwear.\nSuccess rate:30%, MaxHP+30.\nIf failed, the item will be destroyed in a 50% rate."/>
   </imgdir>
   <imgdir name="2040012">
     <string name="name" value="Dark Scroll for Helmet for INT"/>
-    <string name="desc" value="Improves INT on hats.\nSuccess Rate: 70%. INT+2nIf failed, the item will be destroyed in a 50% rate."/>
+    <string name="desc" value="Improves INT on headwear.\nSuccess rate:70%, INT+2.\nIf failed, the item will be destroyed in a 50% rate."/>
   </imgdir>
   <imgdir name="2040013">
     <string name="name" value="Dark Scroll for Helmet for INT"/>
-    <string name="desc" value="Improves INT on hats.\nSuccess Rate: 30%, INT +3nIf failed, the item will be destroyed in a 50% rate."/>
+    <string name="desc" value="Improves INT on headwear.\nSuccess rate:30%, INT+3.\nIf failed, the item will be destroyed in a 50% rate."/>
   </imgdir>
   <imgdir name="2040014">
     <string name="name" value="Dark Scroll for Helmet for Accuracy"/>
-    <string name="desc" value="Improves the accuracy on the helmet.\nSuccess Rate 70%, Dex+1, accuracy +2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on headwear.\nSuccess rate:70%, DEX+1, accuracy+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040015">
     <string name="name" value="Dark Scroll for Helmet for Accuracy"/>
-    <string name="desc" value="Improves the accuracy on the helmet.\nSuccess Rate 30%, Dex+2, accuracy +4nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on headwear.\nSuccess rate:30%, DEX+2, accuracy+4.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040016">
     <string name="name" value="Scroll for Helmet for Accuracy"/>
-    <string name="desc" value="Improves the helmet&apos;s accuracy option.\nSuccess Rate 10%, Dex+2, Accuracy +4. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on headwear.\nSuccess rate:10%, DEX+2, accuracy+4. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040017">
     <string name="name" value="Scroll for Helmet for Accuracy"/>
-    <string name="desc" value="Improves the helmet&apos;s accuracy option.\nSuccess Rate 60%, Dex+1, Accuracy +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on headwear.\nSuccess rate:60%, DEX+1, accuracy+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040018">
     <string name="name" value="Scroll for Helmet for Accuracy"/>
-    <string name="desc" value="Improves the helmet&apos;s accuracy option.\nSuccess Rate 100%, Accuracy +1"/>
+    <string name="desc" value="Improves accuracy on headwear.\nSuccess rate:100%, accuracy+1"/>
   </imgdir>
   <imgdir name="2040019">
     <string name="name" value="Scroll for Helmet for DEF"/>
-    <string name="desc" value="Improves Weapon Defense on a Helmet.\nSuccess rate: 65%, Weapon Def. +2, Magic Def. +1"/>
+    <string name="desc" value="Improves DEF on headwear.\nSuccess rate:65%, weapon def.+2, magic def.+1"/>
   </imgdir>
   <imgdir name="2040020">
     <string name="name" value="Scroll for Helmet for DEF"/>
-    <string name="desc" value="Improves Weapon Defense on a Helmet.\nSuccess rate: 15%, Weapon Def.+5, Magic Def.+3, Accuracy+1"/>
+    <string name="desc" value="Improves DEF on headwear.\nSuccess rate:15%, weapon def.+5, magic def.+3, accuracy+1"/>
   </imgdir>
   <imgdir name="2040021">
     <string name="name" value="Scroll for Helmet for MaxHP"/>
-    <string name="desc" value="Improves MaxHP on a Helmet.\nSuccess rate: 65%, MaxHP +10"/>
+    <string name="desc" value="Improves MaxHP on headwear.\nSuccess rate:65%, MaxHP+10"/>
   </imgdir>
   <imgdir name="2040022">
     <string name="name" value="Scroll for Helmet for MaxHP"/>
-    <string name="desc" value="Improves MaxHP on a Helmet.\nSuccess rate: 15%, MaxHP +30"/>
+    <string name="desc" value="Improves MaxHP on headwear.\nSuccess rate:15%, MaxHP+30"/>
   </imgdir>
   <imgdir name="2040023">
     <string name="name" value="Scroll for Rudolph&apos;s Horn 60%"/>
-    <string name="desc" value="Increases the weapon attack and magic attack of Rudolph&apos;s Horn.\nSuccess rate:60%, attack +1, magic att. +1"/>
+    <string name="desc" value="Increases the weapon attack and magic attack of Rudolph&apos;s Horn.\nSuccess rate:60%, weapon attack+1, magic attack+1"/>
   </imgdir>
   <imgdir name="2040024">
     <string name="name" value="Scroll for Helmet for INT 100%"/>
-    <string name="desc" value="Improves INT on headwear..Success rate 100%, INT+1"/>
+    <string name="desc" value="Improves INT on headwear.\nSuccess rate:100%, INT+1"/>
   </imgdir>
   <imgdir name="2040025">
     <string name="name" value="Scroll for Helmet for INT 60%"/>
-    <string name="desc" value="Improves INT on headwear.\nSuccess rate 60%, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on headwear.\nSuccess rate:60%, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040026">
     <string name="name" value="Scroll for Helmet for INT 10%"/>
-    <string name="desc" value="Improves INT on headwear.\nSuccess rate 10%, INT+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on headwear.\nSuccess rate:10%, INT+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040027">
     <string name="name" value="Scroll for Helmet for DEX 100%"/>
-    <string name="desc" value="Improves DEX on headwear..Success rate 100%, DEX+1"/>
+    <string name="desc" value="Improves DEX on headwear.\nSuccess rate:100%, DEX+1"/>
   </imgdir>
   <imgdir name="2040028">
     <string name="name" value="Scroll for Helmet for DEX 70%"/>
-    <string name="desc" value="Improves DEX on headwear..Success rate 70%, DEX+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on headwear.\nSuccess rate:70%, DEX+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040029">
     <string name="name" value="Scroll for Helmet for DEX 60%"/>
-    <string name="desc" value="Improves DEX on headwear.\nSuccess rate 60%, DEX+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on headwear.\nSuccess rate:60%, DEX+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040030">
     <string name="name" value="Scroll for Helmet for DEX 30%"/>
-    <string name="desc" value="Improves DEX on headwear..Success rate 30%, DEX+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on headwear.\nSuccess rate:30%, DEX+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040031">
     <string name="name" value="Scroll for Helmet for DEX 10%"/>
-    <string name="desc" value="Improves DEX on headwear.\nSuccess rate 10%, DEX+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on headwear.\nSuccess rate:10%, DEX+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040100">
     <string name="name" value="Scroll for Face Accessory for HP"/>
-    <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:10%, MaxHP +30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040101">
     <string name="name" value="Scroll for Face Accessory for HP"/>
-    <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:60%, MaxHP +15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:60%, MaxHP+15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040102">
     <string name="name" value="Scroll for Face Accessory for HP"/>
-    <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:100%, MaxHP +5"/>
+    <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:100%, MaxHP+5"/>
   </imgdir>
   <imgdir name="2040103">
     <string name="name" value="Dark Scroll for Face Accessory for HP"/>
-    <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:30%, MaxHP +30 nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:30%, MaxHP+30.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040104">
     <string name="name" value="Dark Scroll for Face Accessory for HP"/>
-    <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:70%, MaxHP +15 nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:70%, MaxHP+15.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040105">
     <string name="name" value="Scroll for Face Accessory for Avoidability"/>
-    <string name="desc" value="Improves avoidability on face accessories.\nSuccess rate:10%, Avoidability +2, DEX +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves avoidability on face accessories.\nSuccess rate:10%, avoidability+2, DEX+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040106">
     <string name="name" value="Scroll for Face Accessory for Avoidability"/>
-    <string name="desc" value="Improves avoidability on face accessories.\nSuccess rate:60%, Avoidability +1, DEX +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves avoidability on face accessories.\nSuccess rate:60%, avoidability+1, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040107">
     <string name="name" value="Scroll for Face Accessory for Avoidability"/>
-    <string name="desc" value="Improves avoidability on face accessories.\nSuccess rate:100%, Avoidability +1"/>
+    <string name="desc" value="Improves avoidability on face accessories.\nSuccess rate:100%, avoidability+1"/>
   </imgdir>
   <imgdir name="2040108">
     <string name="name" value="Dark Scroll for Face Accessory for Avoidability"/>
-    <string name="desc" value="Improves avoidability on face accessories.\nSuccess rate:30%, Avoidability +2, DEX +2 nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves avoidability on face accessories.\nSuccess rate:30%, avoidability+2, DEX+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040109">
     <string name="name" value="Dark Scroll for Face Accessory for Avoidability"/>
-    <string name="desc" value="Improves avoidability on face accessories.\nSuccess rate:70%, Avoidability +1, DEX +1 nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves avoidability on face accessories.\nSuccess rate:70%, avoidability+1, DEX+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040200">
     <string name="name" value="Scroll for Eye Accessory for Accuracy"/>
-    <string name="desc" value="Improves accuracy on eye accessories.\nSuccess rate:10%, Accuracy +3, DEX +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on eye accessories.\nSuccess rate:10%, accuracy+3, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040201">
     <string name="name" value="Scroll for Eye Accessory for Accuracy"/>
-    <string name="desc" value="Improves accuracy on eye accessories.\nSuccess rate:60%, Accuracy +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on eye accessories.\nSuccess rate:60%, accuracy+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040202">
     <string name="name" value="Scroll for Eye Accessory for Accuracy"/>
-    <string name="desc" value="Improves accuracy on eye accessories.\nSuccess rate:100%, Accuracy +1"/>
+    <string name="desc" value="Improves accuracy on eye accessories.\nSuccess rate:100%, accuracy+1"/>
   </imgdir>
   <imgdir name="2040203">
     <string name="name" value="Dark Scroll for Eye Accessory for Accuracy"/>
-    <string name="desc" value="Improves accuracy on eye accessories.\nSuccess rate:30%, Accuracy +3, DEX +1 nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on eye accessories.\nSuccess rate:30%, accuracy+3, DEX+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040204">
     <string name="name" value="Dark Scroll for Eye Accessory for Accuracy"/>
-    <string name="desc" value="Improves accuracy on eye accessories.\nSuccess rate:70%, Accuracy +2 nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on eye accessories.\nSuccess rate:70%, accuracy+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040205">
     <string name="name" value="Scroll for Eye Accessory for INT"/>
-    <string name="desc" value="Improves INT on eye accessories.\nSuccess rate:10%, INT +3, Magic Def. +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on eye accessories.\nSuccess rate:10%, INT+3, magic def.+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040206">
     <string name="name" value="Scroll for Eye Accessory for INT"/>
-    <string name="desc" value="Improves INT on eye accessories.\nSuccess rate:60%, INT +1, Magic Def. +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on eye accessories.\nSuccess rate:60%, INT+1, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040207">
     <string name="name" value="Scroll for Eye Accessory for INT"/>
-    <string name="desc" value="Improves INT on eye accessories.\nSuccess rate:100%, INT +1"/>
+    <string name="desc" value="Improves INT on eye accessories.\nSuccess rate:100%, INT+1"/>
   </imgdir>
   <imgdir name="2040208">
     <string name="name" value="Dark Scroll for Eye Accessory for INT"/>
-    <string name="desc" value="Improves INT on eye accessories.\nSuccess rate:30%, INT +3, Magic Def. +2 nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves INT on eye accessories.\nSuccess rate:30%, INT+3, magic def.+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040209">
     <string name="name" value="Dark Scroll for Eye Accessory for INT"/>
-    <string name="desc" value="Improves INT on eye accessories.\nSuccess rate:70%, INT +1, Magic Def. +1 nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves INT on eye accessories.\nSuccess rate:70%, INT+1, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040300">
     <string name="name" value="Scroll for Earring for INT"/>
-    <string name="desc" value="Improves INT on ear accessory.\nSuccess rate:100%, magic attack+1"/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:100%, magic attack+1"/>
   </imgdir>
   <imgdir name="2040301">
     <string name="name" value="Scroll for Earring for INT"/>
-    <string name="desc" value="Improves INT on ear accessory.\nSuccess rate:60%, magic attack +2, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:60%, magic attack+2, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040302">
     <string name="name" value="Scroll for Earring for INT"/>
-    <string name="desc" value="Improves INT on ear accessory.\nSuccess rate:10%, magic attack +5, INT+3, magic def. +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:10%, magic attack+5, INT+3, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040303">
     <string name="name" value="Scroll for Earring for INT"/>
-    <string name="desc" value="Improves INT on ear accessory.\nSuccess rate:30%, magic attack +5, INT+3, magic def. +1"/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:30%, magic attack+5, INT+3, magic def.+1"/>
   </imgdir>
   <imgdir name="2040304">
     <string name="name" value="Dark scroll for Earring for INT"/>
-    <string name="desc" value="Improves INT on ear accessory.\nSuccess rate:70%, magic attack +2, INT+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:70%, magic attack+2, INT+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040305">
     <string name="name" value="Dark scroll for Earring for INT"/>
-    <string name="desc" value="Improves INT on ear accessory.\nSuccess rate:30%, magic attack +5, INT+3, magic def. +1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:30%, magic attack+5, INT+3, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040306">
     <string name="name" value="Dark scroll for Earring for DEX"/>
-    <string name="desc" value="Improves DEX on ear accessory.\nSuccess rate: 70%. DEX + 2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on earrings.\nSuccess rate:70%, DEX+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040307">
     <string name="name" value="Dark scroll for Earring for DEX"/>
-    <string name="desc" value="Improves DEX on ear accessorynSuccess rate: 30%. DEX + 3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on earrings.\nSuccess rate:30%, DEX+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040308">
     <string name="name" value="Dark Scroll for Earring for DEF"/>
-    <string name="desc" value="Improves DEF on earringsnSuccess Rate 70%, weapon defense+1, magic defense+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on earrings.\nSuccess rate:70%, weapon def.+1, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040309">
     <string name="name" value="Dark Scroll for Earring for DEF"/>
-    <string name="desc" value="Improves DEF on earringsnSuccess Rate 30%, weapon defense+3, magic defense+3, accuracy+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on earrings.\nSuccess rate:30%, weapon def.+3, magic def.+3, accuracy+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040310">
     <string name="name" value="Scroll for Earring for DEF"/>
-    <string name="desc" value="Improves DEF on earrings.\nSuccess Rate 10%, weapon defense+3, magic defense+3, Accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on earrings.\nSuccess rate:10%, weapon def.+3, magic def.+3, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040311">
     <string name="name" value="Scroll for Earring for DEF"/>
-    <string name="desc" value="Improves DEF on earrings.\nSuccess Rate 60%, weapon defense+1, magic defense+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on earrings.\nSuccess rate:60%, weapon def.+1, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040312">
     <string name="name" value="Scroll for Earring for DEF"/>
-    <string name="desc" value="Improves DEF on earringsnSuccess Rate 100%, weapon defense+1"/>
+    <string name="desc" value="Improves DEF on earrings.\nSuccess rate:100%, weapon def.+1"/>
   </imgdir>
   <imgdir name="2040313">
     <string name="name" value="Scroll for Earring for INT"/>
-    <string name="desc" value="Improves INT on Earrings.\nSuccess rate: 65%, Magic Attack +2, INT+1"/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:65%, magic attack+2, INT+1"/>
   </imgdir>
   <imgdir name="2040314">
     <string name="name" value="Scroll for Earring for INT"/>
-    <string name="desc" value="Improves INT on Earrings.\nSuccess rate:15%, Magic Attack +5, INT +3, Magic Def. +1"/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:15%, magic attack+5, INT+3, magic def.+1"/>
   </imgdir>
   <imgdir name="2040315">
     <string name="name" value="[4yrAnniv]Scroll for Earring for INT"/>
-    <string name="desc" value="Improves INT on Maple Earring.\nSuccess rate: 40%, Magic Attack +3, INT +2 nIf failed, the item has a 30% chance of being destroyed."/>
+    <string name="desc" value="Improves INT on Maple Earring.\nSuccess rate:40%, magic attack+3, INT+2.\nIf failed, the item has a 30% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2040316">
     <string name="name" value="Scroll for Earring for DEX 100%"/>
-    <string name="desc" value="Improves DEX on earrings..\nSuccess rate:100%, DEX+1"/>
+    <string name="desc" value="Improves DEX on earrings.\nSuccess rate:100%, DEX+1"/>
   </imgdir>
   <imgdir name="2040317">
     <string name="name" value="Scroll for Earring for DEX 60%"/>
@@ -1797,11 +1797,11 @@
   </imgdir>
   <imgdir name="2040319">
     <string name="name" value="Scroll for Earring for LUK 100%"/>
-    <string name="desc" value="Improves LUK on earrings..\nSuccess rate:100%, LUK+1"/>
+    <string name="desc" value="Improves LUK on earrings.\nSuccess rate:100%, LUK+1"/>
   </imgdir>
   <imgdir name="2040320">
     <string name="name" value="Scroll for Earring for LUK 70%"/>
-    <string name="desc" value="Improves LUK on earrings..\nSuccess rate:70%, LUK+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on earrings.\nSuccess rate:70%, LUK+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040321">
     <string name="name" value="Scroll for Earring for LUK 60%"/>
@@ -1809,7 +1809,7 @@
   </imgdir>
   <imgdir name="2040322">
     <string name="name" value="Scroll for Earring for LUK 30%"/>
-    <string name="desc" value="Improves LUK on earrings..\nSuccess rate:30%, LUK+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on earrings.\nSuccess rate:30%, LUK+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040323">
     <string name="name" value="Scroll for Earring for LUK 10%"/>
@@ -1817,407 +1817,407 @@
   </imgdir>
   <imgdir name="2040324">
     <string name="name" value="Scroll for Earring for HP 100%"/>
-    <string name="desc" value="Improves HP on earrings..\nSuccess rate:100%, MaxHP+5"/>
+    <string name="desc" value="Improves MaxHP on earrings.\nSuccess rate:100%, MaxHP+5"/>
   </imgdir>
   <imgdir name="2040325">
     <string name="name" value="Scroll for Earring for HP 70%"/>
-    <string name="desc" value="Improves HP on earrings..\nSuccess rate:70%, MaxHP+15nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on earrings.\nSuccess rate:70%, MaxHP+15.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040326">
     <string name="name" value="Scroll for Earring for HP 60%"/>
-    <string name="desc" value="Improves HP on earrings.\nSuccess rate:60%, MaxHP+15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on earrings.\nSuccess rate:60%, MaxHP+15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040327">
     <string name="name" value="Scroll for Earring for HP 30%"/>
-    <string name="desc" value="Improves HP on earrings..\nSuccess rate:30%, MaxHP+30nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on earrings.\nSuccess rate:30%, MaxHP+30.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040328">
     <string name="name" value="Scroll for Earring for HP 10%"/>
-    <string name="desc" value="Improves HP on earrings.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on earrings.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040400">
     <string name="name" value="Scroll for Topwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on topwear.\nSuccess rate:100%, weapon def.+1"/>
+    <string name="desc" value="Improves DEF on topwear.\nSuccess rate:100%, weapon def.+1"/>
   </imgdir>
   <imgdir name="2040401">
     <string name="name" value="Scroll for Topwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on topwear.\nSuccess rate:60%, weapon def.+2, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on topwear.\nSuccess rate:60%, weapon def.+2, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040402">
     <string name="name" value="Scroll for Topwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on topwear.\nSuccess rate:10%, weapon def. +5, magic def. +3, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on topwear.\nSuccess rate:10%, weapon def.+5, magic def.+3, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040403">
     <string name="name" value="Scroll for Topwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on topwear.\nSuccess rate:100%, weapon def. +5, magic def. +3, MaxHP+10"/>
+    <string name="desc" value="Improves DEF on topwear.\nSuccess rate:100%, weapon def.+5, magic def.+3, MaxHP+10"/>
   </imgdir>
   <imgdir name="2040404">
     <string name="name" value="Dark scroll for Topwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on topwear.\nSuccess rate:70%, weapon def. +2, magic def. +1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on topwear.\nSuccess rate:70%, weapon def.+2, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040405">
     <string name="name" value="Dark scroll for Topwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on topwear.\nSuccess rate:30%, weapon def. +5, magic def. +3, MaxHP+10nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on topwear.\nSuccess rate:30%, weapon def.+5, magic def.+3, MaxHP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040406">
     <string name="name" value="Dark scroll for Topwear for STR"/>
-    <string name="desc" value="Improves STR on topwear.\nSuccess rate: 70%, STR + 2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves STR on topwear.\nSuccess rate:70%, STR+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040407">
     <string name="name" value="Dark scroll for Topwear for STR"/>
-    <string name="desc" value="Improves STR on topwear.\nSuccess rate: 30%, STR + 3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves STR on topwear.\nSuccess rate:30%, STR+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040408">
     <string name="name" value="Dark scroll for Topwear for HP"/>
-    <string name="desc" value="Improves HP on topwear.\nSuccess rate: 70%, MaxHP + 15nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on topwear.\nSuccess rate:70%, MaxHP+15.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040409">
     <string name="name" value="Dark scroll for Topwear for HP"/>
-    <string name="desc" value="Improves HP on topwear.\nSuccess rate: 30%, MaxHP + 30nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on topwear.\nSuccess rate:30%, MaxHP+30.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040410">
     <string name="name" value="Dark Scroll for Topwear for LUK"/>
-    <string name="desc" value="Improves LUK on the topwear.\nSuccess Rate 70%, LUK+2, avoidability+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:70%, LUK+2, avoidability+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040411">
     <string name="name" value="Dark Scroll for Topwear for LUK"/>
-    <string name="desc" value="Improves LUK on the topwear.\nSuccess Rate 30%, LUK+3, avoidability+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:30%, LUK+3, avoidability+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040412">
     <string name="name" value="Scroll for Topwear for LUK"/>
-    <string name="desc" value="Improves LUK on the topwear.\nSuccess Rate 10%, LUK+3, avoidability+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:10%, LUK+3, avoidability+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040413">
     <string name="name" value="Scroll for Topwear for LUK"/>
-    <string name="desc" value="Improves LUK on the topwear.\nSuccess Rate 60%, LUK+2, avoidability+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:60%, LUK+2, avoidability+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040414">
     <string name="name" value="Scroll for Topwear for LUK"/>
-    <string name="desc" value="Improves LUK on the topwear.\nSuccess Rate 100%, LUK+1"/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:100%, LUK+1"/>
   </imgdir>
   <imgdir name="2040415">
     <string name="name" value="Scroll for Topwear for DEF"/>
-    <string name="desc" value="Improves Weapon Def. on Topwear.\nSuccess rate: 65%, Weapon Def. +2, Magic Def. +1"/>
+    <string name="desc" value="Improves DEF on topwear.\nSuccess rate:65%, weapon def.+2, magic def.+1"/>
   </imgdir>
   <imgdir name="2040416">
     <string name="name" value="Scroll for Topwear for DEF"/>
-    <string name="desc" value="Improves Weapon Def. on Topwear.\nSuccess rate: 15%, Weapon Def. +5, Magic Def. +3, MaxHP +10"/>
+    <string name="desc" value="Improves DEF on topwear.\nSuccess rate:15%, weapon def.+5, magic def.+3, MaxHP+10"/>
   </imgdir>
   <imgdir name="2040417">
     <string name="name" value="Scroll for Topwear for STR 100%"/>
-    <string name="desc" value="Improves strength on topwear..Success rate 100%, STR+1"/>
+    <string name="desc" value="Improves STR on topwear.\nSuccess rate:100%, STR+1"/>
   </imgdir>
   <imgdir name="2040418">
     <string name="name" value="Scroll for Topwear for STR 60%"/>
-    <string name="desc" value="Improves strength on topwear.\nSuccess rate 60%, STR+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on topwear.\nSuccess rate:60%, STR+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040419">
     <string name="name" value="Scroll for Topwear for STR 10%"/>
-    <string name="desc" value="Improves strength on topwear.\nSuccess rate 10%, STR+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on topwear.\nSuccess rate:10%, STR+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040420">
     <string name="name" value="Scroll for Topwear for HP 100%"/>
-    <string name="desc" value="Improves HP on topwear..Success rate 100%, MaxHP + 5"/>
+    <string name="desc" value="Improves MaxHP on topwear.\nSuccess rate:100%, MaxHP+5"/>
   </imgdir>
   <imgdir name="2040421">
     <string name="name" value="Scroll for Topwear for HP 60%"/>
-    <string name="desc" value="Improves HP on topwear.\nSuccess rate 60%, MaxHP + 15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on topwear.\nSuccess rate:60%, MaxHP+15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040422">
     <string name="name" value="Scroll for Topwear for HP 10%"/>
-    <string name="desc" value="Improves HP on topwear.\nSuccess rate 10%, MaxHP + 30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on topwear.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040423">
     <string name="name" value="Scroll for Topwear for LUK 100%"/>
-    <string name="desc" value="Improves luck on topwear..\nSuccess rate:100%, LUK+1"/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:100%, LUK+1"/>
   </imgdir>
   <imgdir name="2040424">
     <string name="name" value="Scroll for Topwear for LUK 70%"/>
-    <string name="desc" value="Improves luck on topwear..\nSuccess rate:70%, LUK+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:70%, LUK+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040425">
     <string name="name" value="Scroll for Topwear for LUK 60%"/>
-    <string name="desc" value="Improves luck on topwear.\nSuccess rate:60%, LUK+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:60%, LUK+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040426">
     <string name="name" value="Scroll for Topwear for LUK 30%"/>
-    <string name="desc" value="Improves luck on topwear..\nSuccess rate:30%, LUK+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:30%, LUK+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040427">
     <string name="name" value="Scroll for Topwear for LUK 10%"/>
-    <string name="desc" value="Improves luck on topwear.\nSuccess rate:10%, LUK+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:10%, LUK+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040500">
     <string name="name" value="Scroll for Overall Armor for DEX"/>
-    <string name="desc" value="Improves dexterity on the overall armor.\nSuccess rate:100%, DEX+1"/>
+    <string name="desc" value="Improves DEX on overalls.\nSuccess rate:100%, DEX+1"/>
   </imgdir>
   <imgdir name="2040501">
     <string name="name" value="Scroll for Overall Armor for DEX"/>
-    <string name="desc" value="Improves dexterity on the overall armor.\nSuccess rate:60%, DEX+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on overalls.\nSuccess rate:60%, DEX+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040502">
     <string name="name" value="Scroll for Overall Armor for DEX"/>
-    <string name="desc" value="Improves dexterity on the overall armor.\nSuccess rate:10%, DEX+5, accuracy+3, speed+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on overalls.\nSuccess rate:10%, DEX+5, accuracy+3, speed+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040503">
     <string name="name" value="Scroll for Overall Armor for DEF"/>
-    <string name="desc" value="Improves weapon def. on the overall armor.\nSuccess rate:100%, weapon def.+1"/>
+    <string name="desc" value="Improves DEF on overalls.\nSuccess rate:100%, weapon def.+1"/>
   </imgdir>
   <imgdir name="2040504">
     <string name="name" value="Scroll for Overall Armor for DEF"/>
-    <string name="desc" value="Improves def. on the overall armor.\nSuccess rate:60%, weapon def.+2, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on overalls.\nSuccess rate:60%, weapon def.+2, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040505">
     <string name="name" value="Scroll for Overall Armor for DEF"/>
-    <string name="desc" value="Improves def. on the overall armor.\nSuccess rate:10%, wepon def. +5, magic def. +3, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on overalls.\nSuccess rate:10%, weapon def.+5, magic def.+3, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040506">
     <string name="name" value="Scroll for Overall Armor for DEX"/>
-    <string name="desc" value="Improves dexterity on the overall armor.\nSuccess rate:100%, DEX+5, accuracy+3, speed+1"/>
+    <string name="desc" value="Improves DEX on overalls.\nSuccess rate:100%, DEX+5, accuracy+3, speed+1"/>
   </imgdir>
   <imgdir name="2040507">
     <string name="name" value="Scroll for Overall Armor for DEF"/>
-    <string name="desc" value="Improves weapon def. on the overall armor.\nSuccess rate:30%, weapon def.+5, magic def.+3, MaxHP+10"/>
+    <string name="desc" value="Improves DEF on overalls.\nSuccess rate:30%, weapon def.+5, magic def.+3, MaxHP+10"/>
   </imgdir>
   <imgdir name="2040508">
     <string name="name" value="Dark scroll for Overall Armor for DEX"/>
-    <string name="desc" value="Improves dexterity on the overall armor.\nSuccess rate:70%, DEX+2, accuracy+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on overalls.\nSuccess rate:70%, DEX+2, accuracy+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040509">
     <string name="name" value="Dark scroll for Overall Armor for DEX"/>
-    <string name="desc" value="Improves dexterity on the overall armor.\nSuccess rate:30%, DEX+4, accuracy+3, speed+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on overalls.\nSuccess rate:30%, DEX+4, accuracy+3, speed+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040510">
     <string name="name" value="Dark scroll for Overall Armor for DEF"/>
-    <string name="desc" value="Improves weapon def. on the overall armor.\nSuccess rate:70%, weapon def.+2, magic def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on overalls.\nSuccess rate:70%, weapon def.+2, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040511">
     <string name="name" value="Dark scroll for Overall Armor for DEF"/>
-    <string name="desc" value="Improves weapon def. on the overall armor.\nSuccess rate:30%, weapon def.+5, magic def.+3, MaxHP+10nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on overalls.\nSuccess rate:30%, weapon def.+5, magic def.+3, MaxHP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040512">
     <string name="name" value="Scroll for Overall Armor for INT"/>
-    <string name="desc" value="Improves INT on the overall armor.\nSuccess rate: 100%, INT + 1"/>
+    <string name="desc" value="Improves INT on overalls.\nSuccess rate:100%, INT+1"/>
   </imgdir>
   <imgdir name="2040513">
     <string name="name" value="Scroll for Overall Armor for INT"/>
-    <string name="desc" value="Improves INT on the overall armor.\nSuccess rate: 60%, INT + 2, magic def. +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on overalls.\nSuccess rate:60%, INT+2, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040514">
     <string name="name" value="Scroll for Overall Armor for INT"/>
-    <string name="desc" value="Improves INT on the overall armor.\nSuccess rate: 10%, INT + 5, magic def. + 3, MaxMP + 10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on overalls.\nSuccess rate:10%, INT+5, magic def.+3, MaxMP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040515">
     <string name="name" value="Scroll for Overall Armor for LUK"/>
-    <string name="desc" value="Improves LUK on the overall armor.\nSuccess rate: 100%, LUK + 1"/>
+    <string name="desc" value="Improves LUK on overalls.\nSuccess rate:100%, LUK+1"/>
   </imgdir>
   <imgdir name="2040516">
     <string name="name" value="Scroll for Overall Armor for LUK"/>
-    <string name="desc" value="Improves LUK on the overall armor.\nSuccess rate: 60%, LUK + 2, avoidability + 1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on overalls.\nSuccess rate:60%, LUK+2, avoidability+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040517">
     <string name="name" value="Scroll for Overall Armor for LUK"/>
-    <string name="desc" value="Improves LUK on the overall armor.\nSuccess rate: 10%, LUK + 5, avoidability + 3, accuracy + 1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on overalls.\nSuccess rate:10%, LUK+5, avoidability+3, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040518">
     <string name="name" value="Dark scroll for Overall Armor for INT"/>
-    <string name="desc" value="Improves INT on the overall armor.\nSuccess rate:70%, INT+2, magic defense+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves INT on overalls.\nSuccess rate:70%, INT+2, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040519">
     <string name="name" value="Dark scroll for Overall Armor for INT"/>
-    <string name="desc" value="Improves INT on the overall armor.\nSuccess rate:30%, INT+5, magic defense+3, MaxMP+10nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves INT on overalls.\nSuccess rate:30%, INT+5, magic def.+3, MaxMP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040520">
     <string name="name" value="Dark scroll for Overall Armor for LUK"/>
-    <string name="desc" value="Improves LUK on the overall armor.\nSuccess rate:70%, LUK+2, avoidability+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on overalls.\nSuccess rate:70%, LUK+2, avoidability+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040521">
     <string name="name" value="Dark scroll for Overall Armor for LUK"/>
-    <string name="desc" value="Improves LUK on the overall armor.\nSuccess rate:30%, LUK+5, avoidability+3, accuracy+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on overalls.\nSuccess rate:30%, LUK+5, avoidability+3, accuracy+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040522">
     <string name="name" value="Scroll for Overall Armor for DEX"/>
-    <string name="desc" value="Improves DEX on Overall Armor.\nSuccess rate: 65%, DEX +2, Accuracy +1"/>
+    <string name="desc" value="Improves DEX on overalls.\nSuccess rate:65%, DEX+2, accuracy+1"/>
   </imgdir>
   <imgdir name="2040523">
     <string name="name" value="Scroll for Overall Armor for DEX"/>
-    <string name="desc" value="Improves DEX on Overall Armor.\nSuccess rate: 15%, DEX +5, Accuracy+3, Speed +1"/>
+    <string name="desc" value="Improves DEX on overalls.\nSuccess rate:15%, DEX+5, accuracy+3, speed+1"/>
   </imgdir>
   <imgdir name="2040524">
     <string name="name" value="Overall Armor Scroll for DEF"/>
-    <string name="desc" value="Improves Weapon Def. on Overall Armor.\nSuccess rate: 65%, Weapon Def. +2, Magic Def. +1"/>
+    <string name="desc" value="Improves DEF on overalls.\nSuccess rate:65%, weapon def.+2, magic def.+1"/>
   </imgdir>
   <imgdir name="2040525">
     <string name="name" value="Overall Armor Scroll for DEF"/>
-    <string name="desc" value="Improves Weapon Def. on Overall Armor.\nSuccess rate: 15%, Weapon Def. +5, Magic Def. +3, MaxHP +10"/>
+    <string name="desc" value="Improves DEF on overalls.\nSuccess rate:15%, weapon def.+5, magic def.+3, MaxHP+10"/>
   </imgdir>
   <imgdir name="2040526">
     <string name="name" value="Scroll for Overall Armor for INT"/>
-    <string name="desc" value="Improves INT on the Overall Armor.\nSuccess rate: 65%, INT +2, Magic Def. +1"/>
+    <string name="desc" value="Improves INT on overalls.\nSuccess rate:65%, INT+2, magic def.+1"/>
   </imgdir>
   <imgdir name="2040527">
     <string name="name" value="Scroll for Overall Armor for INT"/>
-    <string name="desc" value="Improves INT on the overall armor.\nSuccess rate:15%, INT+5, magic def.+3, MaxMP+10"/>
+    <string name="desc" value="Improves INT on overalls.\nSuccess rate:15%, INT+5, magic def.+3, MaxMP+10"/>
   </imgdir>
   <imgdir name="2040528">
     <string name="name" value="Scroll for Overall Armor for LUK"/>
-    <string name="desc" value="Improves LUK on the overall armor.\nSuccess rate:65%, LUK+2, avoidability+1"/>
+    <string name="desc" value="Improves LUK on overalls.\nSuccess rate:65%, LUK+2, avoidability+1"/>
   </imgdir>
   <imgdir name="2040529">
     <string name="name" value="Scroll for Overall Armor for LUK"/>
-    <string name="desc" value="Improves LUK on the overall armor.\nSuccess rate:15%, LUK+5, avoidability+3, accuracy+1"/>
+    <string name="desc" value="Improves LUK on overalls.\nSuccess rate:15%, LUK+5, avoidability+3, accuracy+1"/>
   </imgdir>
   <imgdir name="2040530">
     <string name="name" value="Scroll for Overall for STR 100%"/>
-    <string name="desc" value="Improves strength on overalls..\nSuccess rate:100%, STR+1"/>
+    <string name="desc" value="Improves STR on overalls.\nSuccess rate:100%, STR+1"/>
   </imgdir>
   <imgdir name="2040531">
     <string name="name" value="Scroll for Overall for STR 70%"/>
-    <string name="desc" value="Improves strength on overalls..\nSuccess rate:70%, STR+2, weapon def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves STR on overalls.\nSuccess rate:70%, STR+2, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040532">
     <string name="name" value="Scroll for Overall for STR 60%"/>
-    <string name="desc" value="Improves strength on overalls.\nSuccess rate:60%, STR+2, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on overalls.\nSuccess rate:60%, STR+2, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040533">
     <string name="name" value="Scroll for Overall for STR 30%"/>
-    <string name="desc" value="Improves strength on overalls..\nSuccess rate:30%, STR+5, weapon def.+3, MaxHp+5nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves STR on overalls.\nSuccess rate:30%, STR+5, weapon def.+3, MaxHP+5.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040534">
     <string name="name" value="Scroll for Overall for STR 10%"/>
-    <string name="desc" value="Improves strength on overalls.\nSuccess rate:10%, STR+5, weapon def.+3, MaxHP+5. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on overalls.\nSuccess rate:10%, STR+5, weapon def.+3, MaxHP+5. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040600">
     <string name="name" value="Scroll for Bottomwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on the bottomwear. nSuccess rate:100%, weapon def. +1"/>
+    <string name="desc" value="Improves DEF on bottomwear.\nSuccess rate:100%, weapon def.+1"/>
   </imgdir>
   <imgdir name="2040601">
     <string name="name" value="Scroll for Bottomwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on the bottomwear.\nSuccess rate:60%, weapon def. +2, magic def. +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on bottomwear.\nSuccess rate:60%, weapon def.+2, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040602">
     <string name="name" value="Scroll for Bottomwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on the bottomwear.\nSuccess rate:10%, weapon def.+5, magic def.+3, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on bottomwear.\nSuccess rate:10%, weapon def.+5, magic def.+3, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040603">
     <string name="name" value="Scroll for Bottomwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on the bottomwear.\nSuccess rate:100%, weapon def.+5, magic def.+3, MaxHP+10"/>
+    <string name="desc" value="Improves DEF on bottomwear.\nSuccess rate:100%, weapon def.+5, magic def.+3, MaxHP+10"/>
   </imgdir>
   <imgdir name="2040604">
     <string name="name" value="Dark scroll for Bottomwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on the bottomwear.\nSuccess rate:70%, weapon def.+2, magic def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on bottomwear.\nSuccess rate:70%, weapon def.+2, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040605">
     <string name="name" value="Dark scroll for Bottomwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on the bottomwear.\nSuccess rate: 30%, weapon def.+5, magic def. + 3, MaxHP + 10nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on bottomwear.\nSuccess rate:30%, weapon def.+5, magic def.+3, MaxHP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040606">
     <string name="name" value="Dark scroll for Bottomwear for Jump"/>
-    <string name="desc" value="Improves jump on the bottomwear.\nSuccess rate: 70%, jump + 2, avoidability + 1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves jump on bottomwear.\nSuccess rate:70%, jump+2, avoidability+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040607">
     <string name="name" value="Dark scroll for Bottomwear for Jump"/>
-    <string name="desc" value="Improves jump on the bottomwear.\nSuccess rate: 30%. jump + 4, avoidability + 2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves jump on bottomwear.\nSuccess rate:30%, jump+4, avoidability+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040608">
     <string name="name" value="Dark scroll for Bottomwear for HP"/>
-    <string name="desc" value="Improves HP on the bottomwear.\nSuccess rate: 70%. MaxHP + 15nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on bottomwear.\nSuccess rate:70%, MaxHP+15.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040609">
     <string name="name" value="Dark scroll for Bottomwear for HP"/>
-    <string name="desc" value="Improves HP on the bottomwear.\nSuccess rate: 30%. MaxHP + 30nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on bottomwear.\nSuccess rate:30%, MaxHP+30.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040610">
     <string name="name" value="Dark Scroll for Bottomwear for DEX"/>
-    <string name="desc" value="Improves dexterity on the bottomwear.\nSuccess Rate 70%, DEX+2, speed+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:70%, DEX+2, speed+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040611">
     <string name="name" value="Dark Scroll for Bottomwear for DEX"/>
-    <string name="desc" value="Improves dexterity on the bottomwear.\nSuccess Rate 30%, DEX+3, speed+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:30%, DEX+3, speed+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040612">
     <string name="name" value="Scroll for Bottomwear for DEX"/>
-    <string name="desc" value="Improves dexterity on the bottomwear.\nSuccess Rate 10%, DEX+3, speed+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:10%, DEX+3, speed+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040613">
     <string name="name" value="Scroll for Bottomwear for DEX"/>
-    <string name="desc" value="Improves dexterity on the bottomwear.\nSuccess Rate 60%, DEX+2, speed+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:60%, DEX+2, speed+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040614">
     <string name="name" value="Scroll for Bottomwear for DEX"/>
-    <string name="desc" value="Improves dexterity on the bottomwear.\nSuccess Rate 100%, DEX+1"/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:100%, DEX+1"/>
   </imgdir>
   <imgdir name="2040615">
     <string name="name" value="Scroll for Bottomwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on bottomwear.\nSuccess rate:65%, weapon def.+2, magic def.+1"/>
+    <string name="desc" value="Improves DEF on bottomwear.\nSuccess rate:65%, weapon def.+2, magic def.+1"/>
   </imgdir>
   <imgdir name="2040616">
     <string name="name" value="Scroll for Bottomwear for DEF"/>
-    <string name="desc" value="Improves weapon def. on bottomwear.\nSuccess rate:15%, weapon def.+5, magic def.+3, MaxHP+10"/>
+    <string name="desc" value="Improves DEF on bottomwear.\nSuccess rate:15%, weapon def.+5, magic def.+3, MaxHP+10"/>
   </imgdir>
   <imgdir name="2040617">
     <string name="name" value="Scroll for Bottomwear for Jump 100%"/>
-    <string name="desc" value="Improves jumping abilities on bottomwears..\nSuccess rate:100%, jump+1"/>
+    <string name="desc" value="Improves jump on bottomwear.\nSuccess rate:100%, jump+1"/>
   </imgdir>
   <imgdir name="2040618">
     <string name="name" value="Scroll for Bottomwear for Jump 60%"/>
-    <string name="desc" value="Improves jumping abilities on bottomwears.\nSuccess rate:60%, jump+2, avoidability+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves jump on bottomwear.\nSuccess rate:60%, jump+2, avoidability+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040619">
     <string name="name" value="Scroll for Bottomwear for Jump 10%"/>
-    <string name="desc" value="Improves jumping abilities on bottomwears..\nSuccess rate:10%, jump+4, avoidability+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves jump on bottomwear.\nSuccess rate:10%, jump+4, avoidability+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040620">
     <string name="name" value="Scroll for Bottomwear for HP 100%"/>
-    <string name="desc" value="Improves HP on bottomwears..\nSuccess rate:100%, MaxHP+5"/>
+    <string name="desc" value="Improves MaxHP on bottomwear.\nSuccess rate:100%, MaxHP+5"/>
   </imgdir>
   <imgdir name="2040621">
     <string name="name" value="Scroll for Bottomwear for HP 60%"/>
-    <string name="desc" value="Improves HP on bottomwears.\nSuccess rate:60%, MaxHP+15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on bottomwear.\nSuccess rate:60%, MaxHP+15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040622">
     <string name="name" value="Scroll for Bottomwear for HP 10%"/>
-    <string name="desc" value="Improves HP on bottomwears.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on bottomwear.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040623">
     <string name="name" value="Scroll for Bottomwear for DEX 100%"/>
-    <string name="desc" value="Improves dexterity on bottomwears..\nSuccess rate:100%, DEX+1"/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:100%, DEX+1"/>
   </imgdir>
   <imgdir name="2040624">
     <string name="name" value="Scroll for Bottomwear for DEX 70%"/>
-    <string name="desc" value="Improves dexterity on bottomwears..\nSuccess rate:70%, DEX+2, accuracy+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:70%, DEX+2, accuracy+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040625">
     <string name="name" value="Scroll for Bottomwear for DEX 60%"/>
-    <string name="desc" value="Improves dexterity on bottomwears.\nSuccess rate:60%, DEX+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:60%, DEX+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040626">
     <string name="name" value="Scroll for Bottomwear for DEX 30%"/>
-    <string name="desc" value="Improves dexterity on bottomwears..\nSuccess rate:30%, DEX+3, accuracy+2, speed+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:30%, DEX+3, accuracy+2, speed+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040627">
     <string name="name" value="Scroll for Bottomwear for DEX 10%"/>
-    <string name="desc" value="Improves dexterity on bottomwears.\nSuccess rate:10%, DEX+3, accuracy+2, speed+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:10%, DEX+3, accuracy+2, speed+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040700">
     <string name="name" value="Scroll for Shoes for DEX"/>
-    <string name="desc" value="Improves dexterity on shoes.\nSuccess rate:100%, Avoidability+1"/>
+    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:100%, avoidability+1"/>
   </imgdir>
   <imgdir name="2040701">
     <string name="name" value="Scroll for Shoes for DEX"/>
-    <string name="desc" value="Improves dexterity on shoes.\nSuccess rate:60%, Avoidability +2, Accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:60%, avoidability+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040702">
     <string name="name" value="Scroll for Shoes for DEX"/>
-    <string name="desc" value="Improves dexterity on shoes.\nSuccess rate:10%, Avoidability +5, accuracy +3, speed+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:10%, avoidability+5, accuracy+3, speed+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040703">
     <string name="name" value="Scroll for Shoes for Jump"/>
-    <string name="desc" value="Improves jump on shoes.\nSuccess rate:100%, jump +1"/>
+    <string name="desc" value="Improves jump on shoes.\nSuccess rate:100%, jump+1"/>
   </imgdir>
   <imgdir name="2040704">
     <string name="name" value="Scroll for Shoes for Jump"/>
-    <string name="desc" value="Improves jump on shoes.\nSuccess rate: 60%, jump +2, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves jump on shoes.\nSuccess rate:60%, jump+2, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040705">
     <string name="name" value="Scroll for Shoes for Jump"/>
@@ -2249,35 +2249,35 @@
   </imgdir>
   <imgdir name="2040712">
     <string name="name" value="Dark scroll for Shoes for DEX"/>
-    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:70%, avoidability+2, accuracy+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:70%, avoidability+2, accuracy+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040713">
     <string name="name" value="Dark scroll for Shoes for DEX"/>
-    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:30%, avoidability+5, accuracy+3, speed+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:30%, avoidability+5, accuracy+3, speed+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040714">
     <string name="name" value="Dark scroll for Shoes for Jump"/>
-    <string name="desc" value="Improves jump on shoes.\nSuccess rate:70%, jump+2, DEX+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves jump on shoes.\nSuccess rate:70%, jump+2, DEX+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040715">
     <string name="name" value="Dark scroll for Shoes for Jump"/>
-    <string name="desc" value="Improves jump on shoes.\nSuccess rate:30%, jump+5, DEX+3, speed+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves jump on shoes.\nSuccess rate:30%, jump+5, DEX+3, speed+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040716">
     <string name="name" value="Dark scroll for Shoes for Speed"/>
-    <string name="desc" value="Improves speed on shoes.\nSuccess rate:70%, speed+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves speed on shoes.\nSuccess rate:70%, speed+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040717">
     <string name="name" value="Dark scroll for Shoes for Speed"/>
-    <string name="desc" value="Improves speed on shoes.\nSuccess rate:30%, speed+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves speed on shoes.\nSuccess rate:30%, speed+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040718">
     <string name="name" value="Scroll for Shoes for DEX"/>
-    <string name="desc" value="Improves dexterity on shoes.\nSuccess rate:65%, avoidability+2, accuracy+1"/>
+    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:65%, avoidability+2, accuracy+1"/>
   </imgdir>
   <imgdir name="2040719">
     <string name="name" value="Scroll for Shoes for DEX"/>
-    <string name="desc" value="Improves dexterity on shoes.\nSuccess rate:15%, avoidability+5, accuracy+3, speed+1"/>
+    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:15%, avoidability+5, accuracy+3, speed+1"/>
   </imgdir>
   <imgdir name="2040720">
     <string name="name" value="Scroll for Shoes for Jump"/>
@@ -2297,203 +2297,203 @@
   </imgdir>
   <imgdir name="2040727">
     <string name="name" value="Scroll for Spikes on Shoes 10%"/>
-    <string name="desc" value="Adds traction to the shoes, which prevents the shoes from slipping on slippery surface.\nSuccess rate:10%, Does not affect the number of upgrades available. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Adds traction to the shoes, which prevents the shoes from slipping on slippery surfaces.\nSuccess rate:10%, Does not affect the number of upgrades available. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040800">
     <string name="name" value="Scroll for Gloves for DEX"/>
-    <string name="desc" value="Improves dexterity on gloves.\nSuccess rate:100%, accuracy +1"/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:100%, accuracy+1"/>
   </imgdir>
   <imgdir name="2040801">
     <string name="name" value="Scroll for Gloves for DEX"/>
-    <string name="desc" value="Improves dexterity on gloves.\nSuccess rate: 60%, accuracy+2, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:60%, accuracy+2, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040802">
     <string name="name" value="Scroll for Gloves for DEX"/>
-    <string name="desc" value="Improves dexterity on gloves.\nSuccess rate:10%, accuracy+5, DEX+3, avoidability+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:10%, accuracy+5, DEX+3, avoidability+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040803">
     <string name="name" value="Scroll for Gloves for ATT"/>
-    <string name="desc" value="Improves attack on gloves.\nSuccess rate:100%, weapon att. +1"/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2040804">
     <string name="name" value="Scroll for Gloves for ATT"/>
-    <string name="desc" value="Improves attack on gloves.\nSuccess rate 60%, weapon att. +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:60%, weapon attack+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040805">
     <string name="name" value="Scroll for Gloves for ATT"/>
-    <string name="desc" value="Improves attack on gloves.\nSuccess rate:10%, weapon att.+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:10%, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040806">
     <string name="name" value="Scroll for Gloves for DEX"/>
-    <string name="desc" value="Improves DEX on the glove.\nSuccess rate:100%, accuracy+5, DEX+3, avoidability+1"/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:100%, accuracy+5, DEX+3, avoidability+1"/>
   </imgdir>
   <imgdir name="2040807">
     <string name="name" value="Scroll for Gloves for ATT"/>
-    <string name="desc" value="Improves weapon att. on the glove.\nSuccess rate:100%, weapon att.+3"/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:100%, weapon attack+3"/>
   </imgdir>
   <imgdir name="2040808">
     <string name="name" value="Dark scroll for Gloves for DEX"/>
-    <string name="desc" value="Improves DEX on the glove.\nSuccess rate:70%, accuracy+2, DEX+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:70%, accuracy+2, DEX+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040809">
     <string name="name" value="Dark scroll for Gloves for DEX"/>
-    <string name="desc" value="Improves DEX on the glove.\nSuccess rate:30%, accuracy+5, DEX+3, avoidability+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:30%, accuracy+5, DEX+3, avoidability+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040810">
     <string name="name" value="Dark scroll for Gloves for ATT"/>
-    <string name="desc" value="Improves weapon att. on the glove.\nSuccess rate:70%, weapon att.+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:70%, weapon attack+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040811">
     <string name="name" value="Dark scroll for Gloves for ATT"/>
-    <string name="desc" value="Improves weapon att. on the glove.\nSuccess rate:30%, weapon att.+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:30%, weapon attack+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040812">
     <string name="name" value="Dark scroll for Gloves for HP"/>
-    <string name="desc" value="Improves HP on the glove.\nSuccess rate: 70%, MaxHP+15nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on gloves.\nSuccess rate:70%, MaxHP+15.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040813">
     <string name="name" value="Dark scroll for Gloves for HP"/>
-    <string name="desc" value="Improves HP on the glove.\nSuccess rate: 30%, MaxHP + 30nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on gloves.\nSuccess rate:30%, MaxHP+30.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040814">
     <string name="name" value="Dark Scroll for Gloves for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the glove.\nSuccess Rate 70%, magic attack+1, INT+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic attack on gloves.\nSuccess rate:70%, magic attack+1, INT+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040815">
     <string name="name" value="Dark Scroll for Gloves for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the glove.\nSuccess Rate 30%, magic attack+3, INT+3, magic defense+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic attack on gloves.\nSuccess rate:30%, magic attack+3, INT+3, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040816">
     <string name="name" value="Scroll for Gloves for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the glove.\nSuccess Rate 10%, magic defense+1, magic attack+3, INT+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic attack on gloves.\nSuccess rate:10%, magic def.+1, magic attack+3, INT+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040817">
     <string name="name" value="Scroll for Gloves for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the glove.\nSuccess Rate 60%, magic attack+1, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic attack on gloves.\nSuccess rate:60%, magic attack+1, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040818">
     <string name="name" value="Scroll for Gloves for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the glove.\nSuccess Rate 100%, magic attack+1"/>
+    <string name="desc" value="Improves magic attack on gloves.\nSuccess rate:100%, magic attack+1"/>
   </imgdir>
   <imgdir name="2040819">
     <string name="name" value="Scroll for Gloves for DEX"/>
-    <string name="desc" value="Improves dexterity on gloves.\nSuccess rate:65%, accuracy+2, DEX+1"/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:65%, accuracy+2, DEX+1"/>
   </imgdir>
   <imgdir name="2040820">
     <string name="name" value="Scroll for Gloves for DEX"/>
-    <string name="desc" value="Improves dexterity on gloves.\nSuccess rate:15%, accuracy+5, DEX+3, avoidability+1"/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:15%, accuracy+5, DEX+3, avoidability+1"/>
   </imgdir>
   <imgdir name="2040821">
     <string name="name" value="Scroll for Gloves for ATT"/>
-    <string name="desc" value="Improves attack on gloves.\nSuccess rate:65%, weapon attack+2"/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:65%, weapon attack+2"/>
   </imgdir>
   <imgdir name="2040822">
     <string name="name" value="Scroll for Gloves for ATT"/>
-    <string name="desc" value="Improves attack on gloves.\nSuccess rate:15%, weapon attack+3"/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:15%, weapon attack+3"/>
   </imgdir>
   <imgdir name="2040823">
     <string name="name" value="Scroll for Gloves for HP 100%"/>
-    <string name="desc" value="Improves HP on gloves..\nSuccess rate:100%, MaxHP+5"/>
+    <string name="desc" value="Improves MaxHP on gloves.\nSuccess rate:100%, MaxHP+5"/>
   </imgdir>
   <imgdir name="2040824">
     <string name="name" value="Scroll for Gloves for HP 60%"/>
-    <string name="desc" value="Improves HP on gloves.\nSuccess rate:60%, MaxHP+15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on gloves.\nSuccess rate:60%, MaxHP+15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040825">
     <string name="name" value="Scroll for Gloves for HP 10%"/>
-    <string name="desc" value="Improves HP on gloves.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on gloves.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040900">
     <string name="name" value="Scroll for Shield for DEF"/>
-    <string name="desc" value="Improves weapon def. on the shield.\nSuccess rate:100%, weapon def. +1"/>
+    <string name="desc" value="Improves DEF on shields.\nSuccess rate:100%, weapon def.+1"/>
   </imgdir>
   <imgdir name="2040901">
     <string name="name" value="Scroll for Shield for DEF"/>
-    <string name="desc" value="Improves weapon def. on the shield.\nSuccess rate:60%, weapon def.+2, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on shields.\nSuccess rate:60%, weapon def.+2, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040902">
     <string name="name" value="Scroll for Shield for DEF"/>
-    <string name="desc" value="Improves weapon def. on the shield.\nSuccess rate 10%, weapon def.+5, magic def.+3, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on shields.\nSuccess rate:10%, weapon def.+5, magic def.+3, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040903">
     <string name="name" value="Scroll for Shield for DEF"/>
-    <string name="desc" value="Improves weapon def. on the shield.\nSuccess rate 100%, weapon def.+5, magic def.+3, MaxHP+10"/>
+    <string name="desc" value="Improves DEF on shields.\nSuccess rate:100%, weapon def.+5, magic def.+3, MaxHP+10"/>
   </imgdir>
   <imgdir name="2040904">
     <string name="name" value="Dark scroll for Shield for DEF"/>
-    <string name="desc" value="Improves weapon def. on the shield.\nSuccess rate 70%, weapon def.+2, magic def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on shields.\nSuccess rate:70%, weapon def.+2, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040905">
     <string name="name" value="Dark scroll for Shield for DEF"/>
-    <string name="desc" value="Improves weapon def. on the shield.\nSuccess rate 30%, weapon def.+5, magic def.+3, MaxHP+10nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on shields.\nSuccess rate:30%, weapon def.+5, magic def.+3, MaxHP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040906">
     <string name="name" value="Dark scroll for Shield for LUK"/>
-    <string name="desc" value="Improves LUK on the shield.\nSuccess rate: 70%, LUK + 2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on shields.\nSuccess rate:70%, LUK+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040907">
     <string name="name" value="Dark scroll for Shield for LUK"/>
-    <string name="desc" value="Improves LUK on the shield.\nSuccess rate: 30%, LUK + 3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on shields.\nSuccess rate:30%, LUK+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040908">
     <string name="name" value="Dark scroll for Shield for HP"/>
-    <string name="desc" value="Improves HP on the shield.\nSuccess rate: 70%, MaxHP + 15nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on shields.\nSuccess rate:70%, MaxHP+15.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040909">
     <string name="name" value="Dark scroll for Shield for HP"/>
-    <string name="desc" value="Improves HP on the shield.\nSuccess rate: 30%, MaxHP + 30nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on shields.\nSuccess rate:30%, MaxHP+30.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040910">
     <string name="name" value="Scroll for Shield for DEF"/>
-    <string name="desc" value="Improves weapon defense on the shield.\nSuccess rate:65%, weapon def.+2, magic def.+1"/>
+    <string name="desc" value="Improves DEF on shields.\nSuccess rate:65%, weapon def.+2, magic def.+1"/>
   </imgdir>
   <imgdir name="2040911">
     <string name="name" value="Scroll for Shield for DEF"/>
-    <string name="desc" value="Improves weapon defense on the shield.\nSuccess rate:15%, weapon def.+5, magic def.+3, MaxHP+10"/>
+    <string name="desc" value="Improves DEF on shields.\nSuccess rate:15%, weapon def.+5, magic def.+3, MaxHP+10"/>
   </imgdir>
   <imgdir name="2040912">
     <string name="name" value="[4yrAnniv]Scroll for Shield for DEF"/>
-    <string name="desc" value="Improves weapon defense for Maple Magician shield, Maple warrior shield, and the Maple Shibus shield. nSuccess rate:40%, weapon def.+3, magic def.+2 nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves DEF for Maple Magician Shield, Maple Warrior Shield, and the Maple Shibus shield.\nSuccess rate:40%, weapon def.+3, magic def.+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2040914">
     <string name="name" value="Scroll for Shield for Weapon Att."/>
-    <string name="desc" value="Improves weapon attack on the shield.\nSuccess Rate 60%, W. attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on shields.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040915">
     <string name="name" value="Scroll for Shield for Weapon Att."/>
-    <string name="desc" value="Improves weapon attack on the shield.\nSuccess Rate 10%, W. attack+3, STR+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on shields.\nSuccess rate:10%, weapon attack+3, STR+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040916">
     <string name="name" value="Dark Scroll for Shield for Weapon Att."/>
-    <string name="desc" value="Improves weapon attack on the shield.\nSuccess Rate 70%, W. attack+2, STR+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on shields.\nSuccess rate:70%, weapon attack+2, STR+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040917">
     <string name="name" value="Dark Scroll for Shield for Weapon Att."/>
-    <string name="desc" value="Improves weapon attack on the shield.\nSuccess Rate 30%, W. attack+3, STR+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on shields.\nSuccess rate:30%, weapon attack+3, STR+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040918">
     <string name="name" value="Scroll for Shield for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the shield.\nSuccess Rate 100%, magic attack+1"/>
+    <string name="desc" value="Improves magic attack on shields.\nSuccess rate:100%, magic attack+1"/>
   </imgdir>
   <imgdir name="2040919">
     <string name="name" value="Scroll for Shield for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the shield.\nSuccess Rate 60%, magic attack+2, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic attack on shields.\nSuccess rate:60%, magic attack+2, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040920">
     <string name="name" value="Scroll for Shield for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the shield.\nSuccess Rate 10%, magic attack+3, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic attack on shields.\nSuccess rate:10%, magic attack+3, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040921">
     <string name="name" value="Dark Scroll for Shield for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the shield.\nSuccess Rate 70%, magic attack+2, INT+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic attack on shields.\nSuccess rate:70%, magic attack+2, INT+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040922">
     <string name="name" value="Dark Scroll for Shield for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the shield.\nSuccess Rate 50%, magic attack+3, INT+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic attack on shields.\nSuccess rate:50%, magic attack+3, INT+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040923">
     <string name="name" value="Scroll for Shield for LUK 100%"/>
-    <string name="desc" value="Improves LUK on shields..\nSuccess rate:100%, LUK+1"/>
+    <string name="desc" value="Improves LUK on shields.\nSuccess rate:100%, LUK+1"/>
   </imgdir>
   <imgdir name="2040924">
     <string name="name" value="Scroll for Shield for LUK 60%"/>
@@ -2505,351 +2505,351 @@
   </imgdir>
   <imgdir name="2040926">
     <string name="name" value="Scroll for Shield for HP 100%"/>
-    <string name="desc" value="Improves HP on shields..\nSuccess rate:100%, MaxHP+5"/>
+    <string name="desc" value="Improves MaxHP on shields.\nSuccess rate:100%, MaxHP+5"/>
   </imgdir>
   <imgdir name="2040927">
     <string name="name" value="Scroll for Shield for HP 60%"/>
-    <string name="desc" value="Improves HP on shields.\nSuccess rate:60%, MaxHP+15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on shields.\nSuccess rate:60%, MaxHP+15. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040928">
     <string name="name" value="Scroll for Shield for HP 10%"/>
-    <string name="desc" value="Improves HP on shields.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on shields.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040929">
     <string name="name" value="Scroll for Shield for STR 100%"/>
-    <string name="desc" value="Improves strength on shields..\nSuccess rate:100%, STR+1"/>
+    <string name="desc" value="Improves STR on shields.\nSuccess rate:100%, STR+1"/>
   </imgdir>
   <imgdir name="2040930">
     <string name="name" value="Scroll for Shield for STR 70%"/>
-    <string name="desc" value="Improves strength on shields..\nSuccess rate:70%, STR+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves STR on shields.\nSuccess rate:70%, STR+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040931">
     <string name="name" value="Scroll for Shield for STR 60%"/>
-    <string name="desc" value="Improves strength on shields.\nSuccess rate:60%, STR+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on shields.\nSuccess rate:60%, STR+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040932">
     <string name="name" value="Scroll for Shield for STR 30%"/>
-    <string name="desc" value="Improves strength on shields..\nSuccess rate:30%, STR+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves STR on shields.\nSuccess rate:30%, STR+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2040933">
     <string name="name" value="Scroll for Shield for STR 10%"/>
-    <string name="desc" value="Improves strength on shields.\nSuccess rate:10%, STR+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on shields.\nSuccess rate:10%, STR+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041000">
     <string name="name" value="Scroll for Cape for Magic Def."/>
-    <string name="desc" value="Improves magic def. on the cape.\nSuccess rate:100%, magic def. +1"/>
+    <string name="desc" value="Improves magic def. on capes.\nSuccess rate:100%, magic def.+1"/>
   </imgdir>
   <imgdir name="2041001">
     <string name="name" value="Scroll for Cape for Magic Def."/>
-    <string name="desc" value="Improves magic def. on the cape.\nSuccess rate:60%, magic def.+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic def. on capes.\nSuccess rate:60%, magic def.+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041002">
     <string name="name" value="Scroll for Cape for Magic Def."/>
-    <string name="desc" value="Improves magic def. on the cape.\nSuccess rate:10%, magic def. +5, weapon def. +3, MaxMP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic def. on capes.\nSuccess rate:10%, magic def.+5, weapon def.+3, MaxMP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041003">
     <string name="name" value="Scroll for Cape for Weapon Def."/>
-    <string name="desc" value="Improves weapon def. on the cape.\nSuccess rate:100%, weapon def.+1"/>
+    <string name="desc" value="Improves DEF on capes.\nSuccess rate:100%, weapon def.+1"/>
   </imgdir>
   <imgdir name="2041004">
     <string name="name" value="Scroll for Cape for Weapon Def."/>
-    <string name="desc" value="Improves weapon def. on the cape.\nSuccess rate:60%, weapon def.+3, magic def. +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on capes.\nSuccess rate:60%, weapon def.+3, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041005">
     <string name="name" value="Scroll for Cape for Weapon Def."/>
-    <string name="desc" value="Improves weapon def. on the cape.\nSuccess rate:10%, weapon def. +5, magic def.+3, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEF on capes.\nSuccess rate:10%, weapon def.+5, magic def.+3, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041006">
     <string name="name" value="Scroll for Cape for HP"/>
-    <string name="desc" value="Improves MaxHP on the cape.\nSuccess rate:100%, MaxHP+5"/>
+    <string name="desc" value="Improves MaxHP on capes.\nSuccess rate:100%, MaxHP+5"/>
   </imgdir>
   <imgdir name="2041007">
     <string name="name" value="Scroll for Cape for HP"/>
-    <string name="desc" value="Improves MaxHP on the cape.\nSuccess rate:60%, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on capes.\nSuccess rate:60%, MaxHP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041008">
     <string name="name" value="Scroll for Cape for HP"/>
-    <string name="desc" value="Improves MaxHP on the cape.\nSuccess rate:10%, MaxHP+20. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxHP on capes.\nSuccess rate:10%, MaxHP+20. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041009">
     <string name="name" value="Scroll for Cape for MP"/>
-    <string name="desc" value="Improves MaxMP on the cape.\nSuccess rate:100%, MaxMP+5"/>
+    <string name="desc" value="Improves MaxMP on capes.\nSuccess rate:100%, MaxMP+5"/>
   </imgdir>
   <imgdir name="2041010">
     <string name="name" value="Scroll for Cape for MP"/>
-    <string name="desc" value="Improves MaxMP on the cape.\nSuccess rate:60%, MaxMP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxMP on capes.\nSuccess rate:60%, MaxMP+10. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041011">
     <string name="name" value="Scroll for Cape for MP"/>
-    <string name="desc" value="Improves MaxMP on the cape.\nSuccess rate:10%, MaxMP+20. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves MaxMP on capes.\nSuccess rate:10%, MaxMP+20. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041012">
     <string name="name" value="Scroll for Cape for STR"/>
-    <string name="desc" value="Improves STR on the cape.\nSuccess rate:100%, STR+1"/>
+    <string name="desc" value="Improves STR on capes.\nSuccess rate:100%, STR+1"/>
   </imgdir>
   <imgdir name="2041013">
     <string name="name" value="Scroll for Cape for STR"/>
-    <string name="desc" value="Improves STR on the cape.\nSuccess rate:60%, STR+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on capes.\nSuccess rate:60%, STR+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041014">
     <string name="name" value="Scroll for Cape for STR"/>
-    <string name="desc" value="Improves STR on the cape.\nSuccess rate:10%, STR+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on capes.\nSuccess rate:10%, STR+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041015">
     <string name="name" value="Scroll for Cape for INT"/>
-    <string name="desc" value="Improves INT on the cape.\nSuccess rate:100%, INT+1"/>
+    <string name="desc" value="Improves INT on capes.\nSuccess rate:100%, INT+1"/>
   </imgdir>
   <imgdir name="2041016">
     <string name="name" value="Scroll for Cape for INT"/>
-    <string name="desc" value="Improves INT on the cape.\nSuccess rate:60%, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on capes.\nSuccess rate:60%, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041017">
     <string name="name" value="Scroll for Cape for INT"/>
-    <string name="desc" value="Improves INT on the cape.\nSuccess rate:10%, INT+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on capes.\nSuccess rate:10%, INT+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041018">
     <string name="name" value="Scroll for Cape for DEX"/>
-    <string name="desc" value="Improves DEX on the cape.\nSuccess rate:100%, DEX+1"/>
+    <string name="desc" value="Improves DEX on capes.\nSuccess rate:100%, DEX+1"/>
   </imgdir>
   <imgdir name="2041019">
     <string name="name" value="Scroll for Cape for DEX"/>
-    <string name="desc" value="Improves DEX on the cape.\nSuccess rate:60%, DEX+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on capes.\nSuccess rate:60%, DEX+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041020">
     <string name="name" value="Scroll for Cape for DEX"/>
-    <string name="desc" value="Improves DEX on the cape.\nSuccess rate:10%, DEX+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on capes.\nSuccess rate:10%, DEX+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041021">
     <string name="name" value="Scroll for Cape for LUK"/>
-    <string name="desc" value="Improves LUK on the cape.\nSuccess rate:100%, LUK+1"/>
+    <string name="desc" value="Improves LUK on capes.\nSuccess rate:100%, LUK+1"/>
   </imgdir>
   <imgdir name="2041022">
     <string name="name" value="Scroll for Cape for LUK"/>
-    <string name="desc" value="Improves LUK on the cape.\nSuccess rate:60%, LUK+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on capes.\nSuccess rate:60%, LUK+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041023">
     <string name="name" value="Scroll for Cape for LUK"/>
-    <string name="desc" value="Improves LUK on the cape.\nSuccess rate:10%, LUK+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on capes.\nSuccess rate:10%, LUK+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041024">
     <string name="name" value="Scroll for Cape for Magic Def."/>
-    <string name="desc" value="Improves magic def. on the cape.\nSuccess rate:100%, magic def.+5, weapon def.+3, MaxMP+10"/>
+    <string name="desc" value="Improves magic def. on capes.\nSuccess rate:100%, magic def.+5, weapon def.+3, MaxMP+10"/>
   </imgdir>
   <imgdir name="2041025">
     <string name="name" value="Scroll for Cape for Weapon Def."/>
-    <string name="desc" value="Improves weapon def. on the cape.\nSuccess rate:100%, weapon def.+5, magic def.+3, MaxHP+10"/>
+    <string name="desc" value="Improves DEF on capes.\nSuccess rate:100%, weapon def.+5, magic def.+3, MaxHP+10"/>
   </imgdir>
   <imgdir name="2041026">
     <string name="name" value="Dark scroll for Cape for Magic Def."/>
-    <string name="desc" value="Improves magic def. on the cape.\nSuccess rate:70%, magic def.+3, weapon def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic def. on capes.\nSuccess rate:70%, magic def.+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041027">
     <string name="name" value="Dark scroll for Cape for Magic Def."/>
-    <string name="desc" value="Improves magic def. on the cape.\nSuccess rate:30%, magic def.+5, weapon def.+3, MaxMP+10nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic def. on capes.\nSuccess rate:30%, magic def.+5, weapon def.+3, MaxMP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041028">
     <string name="name" value="Dark scroll for Cape for Weapon Def."/>
-    <string name="desc" value="Improves weapon def. on the cape.\nSuccess rate:70%, weapon def.+3, magic def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on capes.\nSuccess rate:70%, weapon def.+3, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041029">
     <string name="name" value="Dark scroll for Cape for Weapon Def."/>
-    <string name="desc" value="Improves weapon def. on the cape.\nSuccess rate:30%, weapon def.+5, magic def.+3, MaxHP+10nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEF on capes.\nSuccess rate:30%, weapon def.+5, magic def.+3, MaxHP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041030">
     <string name="name" value="Dark scroll for Cape for HP"/>
-    <string name="desc" value="Improves MaxHP on the cape.\nSuccess rate:70%, MaxHP+10nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on capes.\nSuccess rate:70%, MaxHP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041031">
     <string name="name" value="Dark scroll for Cape for HP"/>
-    <string name="desc" value="Improves MaxHP on the cape.\nSuccess rate:30%, MaxHP+20nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on capes.\nSuccess rate:30%, MaxHP+20.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041032">
     <string name="name" value="Dark scroll for Cape for MP"/>
-    <string name="desc" value="Improves MaxMP on the cape.\nSuccess rate:70%, MaxMP+10nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxMP on capes.\nSuccess rate:70%, MaxMP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041033">
     <string name="name" value="Dark scroll for Cape for MP"/>
-    <string name="desc" value="Improves MaxMP on the cape.\nSuccess rate:30%, MaxMP+20nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxMP on capes.\nSuccess rate:30%, MaxMP+20.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041034">
     <string name="name" value="Dark scroll for Cape for STR"/>
-    <string name="desc" value="Improves STR on the cape.\nSuccess rate:70%, STR+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves STR on capes.\nSuccess rate:70%, STR+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041035">
     <string name="name" value="Dark scroll for Cape for STR"/>
-    <string name="desc" value="Improves STR on the cape.\nSuccess rate:30%, STR+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves STR on capes.\nSuccess rate:30%, STR+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041036">
     <string name="name" value="Dark scroll for Cape for INT"/>
-    <string name="desc" value="Improves INT on the cape.\nSuccess rate:70%, INT+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves INT on capes.\nSuccess rate:70%, INT+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041037">
     <string name="name" value="Dark scroll for Cape for INT"/>
-    <string name="desc" value="Improves INT on the cape.\nSuccess rate:30%, INT+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves INT on capes.\nSuccess rate:30%, INT+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041038">
     <string name="name" value="Dark scroll for Cape for DEX"/>
-    <string name="desc" value="Improves DEX on the cape.\nSuccess rate:70%, DEX+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on capes.\nSuccess rate:70%, DEX+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041039">
     <string name="name" value="Dark scroll for Cape for DEX"/>
-    <string name="desc" value="Improves DEX on the cape.\nSuccess rate:30%, DEX+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on capes.\nSuccess rate:30%, DEX+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041040">
     <string name="name" value="Dark scroll for Cape for LUK"/>
-    <string name="desc" value="Improves LUK on the cape.\nSuccess rate:70%, LUK+2nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on capes.\nSuccess rate:70%, LUK+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041041">
     <string name="name" value="Dark scroll for Cape for LUK"/>
-    <string name="desc" value="Improves LUK on the cape.\nSuccess rate:30%, LUK+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on capes.\nSuccess rate:30%, LUK+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2041042">
     <string name="name" value="Scroll for Cape for Magic DEF"/>
-    <string name="desc" value="Improves magic defense on the cape.\nSuccess rate:65%, magic def.+3, weapon def.+1"/>
+    <string name="desc" value="Improves magic def. on capes.\nSuccess rate:65%, magic def.+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2041043">
     <string name="name" value="Scroll for Cape for Magic DEF"/>
-    <string name="desc" value="Improves magic defense on the cape.\nSuccess rate:15%, magic def.+5, weapon def.+3, MaxMP+10"/>
+    <string name="desc" value="Improves magic def. on capes.\nSuccess rate:15%, magic def.+5, weapon def.+3, MaxMP+10"/>
   </imgdir>
   <imgdir name="2041044">
     <string name="name" value="Scroll for Cape for Weapon DEF"/>
-    <string name="desc" value="Improves weapon defense on the cape.\nSuccess rate:65%, weapon def.+3, magic def.+1"/>
+    <string name="desc" value="Improves DEF on capes.\nSuccess rate:65%, weapon def.+3, magic def.+1"/>
   </imgdir>
   <imgdir name="2041045">
     <string name="name" value="Scroll for Cape for Weapon DEF"/>
-    <string name="desc" value="Improves weapon defense on the cape.\nSuccess rate:15%, weapon def.+5, magic def.+3, MaxHP+10"/>
+    <string name="desc" value="Improves DEF on capes.\nSuccess rate:15%, weapon def.+5, magic def.+3, MaxHP+10"/>
   </imgdir>
   <imgdir name="2041046">
     <string name="name" value="Scroll for Cape for MaxHP"/>
-    <string name="desc" value="Improves MaxHP on the cape.\nSuccess rate:65%, MaxHP+10"/>
+    <string name="desc" value="Improves MaxHP on capes.\nSuccess rate:65%, MaxHP+10"/>
   </imgdir>
   <imgdir name="2041047">
     <string name="name" value="Scroll for Cape for MaxHP"/>
-    <string name="desc" value="Improves MaxHP on the cape.\nSuccess rate:15%, MaxHP+20"/>
+    <string name="desc" value="Improves MaxHP on capes.\nSuccess rate:15%, MaxHP+20"/>
   </imgdir>
   <imgdir name="2041048">
     <string name="name" value="Scroll for Cape for MP"/>
-    <string name="desc" value="Improves MaxMP on the cape.\nSuccess rate:65%, MaxMP+10"/>
+    <string name="desc" value="Improves MaxMP on capes.\nSuccess rate:65%, MaxMP+10"/>
   </imgdir>
   <imgdir name="2041049">
     <string name="name" value="Scroll for Cape for MP"/>
-    <string name="desc" value="Improves MaxMP on the cape.\nSuccess rate:15%, MaxMP+20"/>
+    <string name="desc" value="Improves MaxMP on capes.\nSuccess rate:15%, MaxMP+20"/>
   </imgdir>
   <imgdir name="2041050">
     <string name="name" value="Scroll for Cape for STR"/>
-    <string name="desc" value="Improves STR on the cape.\nSuccess rate:65%, STR+2"/>
+    <string name="desc" value="Improves STR on capes.\nSuccess rate:65%, STR+2"/>
   </imgdir>
   <imgdir name="2041051">
     <string name="name" value="Scroll for Cape for STR"/>
-    <string name="desc" value="Improves STR on the cape.\nSuccess rate:15%, STR+3"/>
+    <string name="desc" value="Improves STR on capes.\nSuccess rate:15%, STR+3"/>
   </imgdir>
   <imgdir name="2041052">
     <string name="name" value="Scroll for Cape for INT"/>
-    <string name="desc" value="Improves INT on the cape.\nSuccess rate:65%, INT+2"/>
+    <string name="desc" value="Improves INT on capes.\nSuccess rate:65%, INT+2"/>
   </imgdir>
   <imgdir name="2041053">
     <string name="name" value="Scroll for Cape for INT"/>
-    <string name="desc" value="Improves INT on the cape.\nSuccess rate:15%, INT+3"/>
+    <string name="desc" value="Improves INT on capes.\nSuccess rate:15%, INT+3"/>
   </imgdir>
   <imgdir name="2041054">
     <string name="name" value="Scroll for Cape for DEX"/>
-    <string name="desc" value="Improves dexterity on the cape.\nSuccess rate:65%, DEX+2"/>
+    <string name="desc" value="Improves DEX on capes.\nSuccess rate:65%, DEX+2"/>
   </imgdir>
   <imgdir name="2041055">
     <string name="name" value="Scroll for Cape for DEX"/>
-    <string name="desc" value="Improves dexterity on the cape.\nSuccess rate:15%, DEX+3"/>
+    <string name="desc" value="Improves DEX on capes.\nSuccess rate:15%, DEX+3"/>
   </imgdir>
   <imgdir name="2041056">
     <string name="name" value="Scroll for Cape for LUK"/>
-    <string name="desc" value="Improves LUK on the cape.\nSuccess rate:65%, LUK+2"/>
+    <string name="desc" value="Improves LUK on capes.\nSuccess rate:65%, LUK+2"/>
   </imgdir>
   <imgdir name="2041057">
     <string name="name" value="Scroll for Cape for LUK"/>
-    <string name="desc" value="Improves LUK on the cape.\nSuccess rate:15%, LUK+3"/>
+    <string name="desc" value="Improves LUK on capes.\nSuccess rate:15%, LUK+3"/>
   </imgdir>
   <imgdir name="2041058">
     <string name="name" value="Scroll for Cape for Cold Protection 10%"/>
-    <string name="desc" value="Includes the effect of protection from cold weather on the cape.\nSuccess rate: 10%. Does not affect the number of upgrades available. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Includes the effect of protection from cold weather on the cape.\nSuccess rate:10%. Does not affect the number of upgrades available. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041059">
     <string name="name" value="[4yrAnniv] Scroll for Cape for STR 20%"/>
-    <string name="desc" value="Improves strength on Maple Cape.\nSuccess rate:20%, STR+3 nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves STR on the Maple Cape.\nSuccess rate:20%, STR+3.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2041060">
     <string name="name" value="[4yrAnniv] Scroll for Cape for INT 20%"/>
-    <string name="desc" value="Improves INT on Maple Cape.\nSuccess rate:20%, INT+3 nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves INT on the Maple Cape.\nSuccess rate:20%, INT+3.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2041061">
     <string name="name" value="[4yrAnniv] Scroll for Cape for DEX 20%"/>
-    <string name="desc" value="Improves dexterity on Maple Cape.\nSuccess rate:20%, DEX+3 nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves DEX on the Maple Cape.\nSuccess rate:20%, DEX+3.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2041062">
     <string name="name" value="[4yrAnniv] Scroll for Cape for LUK 20%"/>
-    <string name="desc" value="Improves luck on Maple Cape.\nSuccess rate:20%, LUK+3 nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves LUK on the Maple Cape.\nSuccess rate:20%, LUK+3.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2041200">
     <string name="name" value="Dragon Stone"/>
-    <string name="desc" value="A powerful stone that contains the mysterious power of the dragon. Can only be used on Horntail Necklace.\nSuccess rate:100%, Weapon Defense +140, Magic Defense +140, Avoidability +15, All Stats +15"/>
+    <string name="desc" value="A powerful stone that contains the mysterious power of the dragon. Can only be used on Horntail Necklace.\nSuccess rate:100%, weapon def.+140, magic def.+140, avoidability+15, All Stats+15"/>
   </imgdir>
   <imgdir name="2041212">
     <string name="name" value="Rock of Wisdom"/>
-    <string name="desc" value="Can only be used on Horus&apos;s Eye.\nSuccess rate:60%, HP +70, MP +70"/>
+    <string name="desc" value="Can only be used on Horus&apos;s Eye.\nSuccess rate:60%, HP+70, MP+70"/>
   </imgdir>
   <imgdir name="2043000">
     <string name="name" value="Scroll for One-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on one-handed sword.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed swords.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2043001">
     <string name="name" value="Scroll for One-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on one-handed sword.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on one-handed swords.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043002">
     <string name="name" value="Scroll for One-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on one-handed sword.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on one-handed swords.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043003">
     <string name="name" value="Scroll for One-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on one-handed sword.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed swords.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2043004">
     <string name="name" value="Dark scroll for One-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on one-handed sword.\nSuccess rate:70%, weapon attack+2, STR+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on one-handed swords.\nSuccess rate:70%, weapon attack+2, STR+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043005">
     <string name="name" value="Dark scroll for One-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on one-handed sword.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on one-handed swords.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043006">
     <string name="name" value="Dark Scroll for One-Handed Sword for Magic Att."/>
-    <string name="desc" value="Improves magic attack on one-handed sword.\nSuccess Rate 70%, magic attack+1, INT+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic attack on one-handed swords.\nSuccess rate:70%, magic attack+1, INT+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043007">
     <string name="name" value="Dark Scroll for One-Handed Sword for Magic Att."/>
-    <string name="desc" value="Improves magic attack on one-handed sword.\nSuccess Rate 30%, magic attack+2, INT+2, magic defense+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic attack on one-handed swords.\nSuccess rate:30%, magic attack+2, INT+2, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043008">
     <string name="name" value="Scroll for One-Handed Sword for Magic Att."/>
-    <string name="desc" value="Improves magic attack on one-handed sword.\nSuccess Rate 10%, magic attack+2, magic defense+1, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic attack on one-handed swords.\nSuccess rate:10%, magic attack+2, magic def.+1, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043009">
     <string name="name" value="Scroll for One-Handed Sword for Magic Att."/>
-    <string name="desc" value="Improves magic attack on one-handed sword.\nSuccess Rate 60%, magic attack+1, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic attack on one-handed swords.\nSuccess rate:60%, magic attack+1, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043010">
     <string name="name" value="Scroll for One-Handed Sword for Magic Att."/>
-    <string name="desc" value="Improves magic attack on one-handed sword.\nSuccess Rate 100%, magic attack+1"/>
+    <string name="desc" value="Improves magic attack on one-handed swords.\nSuccess rate:100%, magic attack+1"/>
   </imgdir>
   <imgdir name="2043011">
     <string name="name" value="Scroll for One-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on the one-handed sword.\nSuccess rate:65%, weapon attack+2, STR+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed swords.\nSuccess rate:65%, weapon attack+2, STR+1"/>
   </imgdir>
   <imgdir name="2043012">
     <string name="name" value="Scroll for One-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on the one-handed sword.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed swords.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2043013">
     <string name="name" value="[4yrAnniv]Scroll for One-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack for Maple Glory Sword. nSuccess rate:40%, weapon attack+3, STR+2 nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack for Maple Glory Sword.\nSuccess rate:40%, weapon attack+3, STR+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2043015">
     <string name="name" value="Scroll for One-Handed Sword for Accuracy 100%"/>
@@ -2857,275 +2857,275 @@
   </imgdir>
   <imgdir name="2043016">
     <string name="name" value="Scroll for One-Handed Sword for Accuracy 70%"/>
-    <string name="desc" value="Improves accuracy on one-handed swords.\nSuccess rate:70%, accuracy+3, DEX+2, weapon att.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on one-handed swords.\nSuccess rate:70%, accuracy+3, DEX+2, weapon attack+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043017">
     <string name="name" value="Scroll for One-Handed Sword for Accuracy 60%"/>
-    <string name="desc" value="Improves accuracy on one-handed swords.\nSuccess rate:60%, accuracy+3, DEX+2, weapon att.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on one-handed swords.\nSuccess rate:60%, accuracy+3, DEX+2, weapon attack+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043018">
     <string name="name" value="Scroll for One-Handed Sword for Accuracy 30%"/>
-    <string name="desc" value="Improves accuracy on one-handed swords.\nSuccess rate:30%, accuracy+5, DEX+3, weapon att.+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on one-handed swords.\nSuccess rate:30%, accuracy+5, DEX+3, weapon attack+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043019">
     <string name="name" value="Scroll for One-Handed Sword for Accuracy 10%"/>
-    <string name="desc" value="Improves accuracy on one-handed swords.\nSuccess rate:10%, accuracy+5, DEX+3, weapon att.+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on one-handed swords.\nSuccess rate:10%, accuracy+5, DEX+3, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043100">
     <string name="name" value="Scroll for One-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on one-handed axe.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed axes.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2043101">
     <string name="name" value="Scroll for One-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on one-handed axe.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on one-handed axes.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043102">
     <string name="name" value="Scroll for One-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on one-handed axe.\nSuccess rate: 10%, weapon attack +5, STR+3, weapon def. +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on one-handed axes.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043103">
     <string name="name" value="Scroll for One-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on one-handed axe.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed axes.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2043104">
     <string name="name" value="Dark scroll for One-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on one-handed axe.\nSuccess rate:70%, weapon attack+2, STR+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on one-handed axes.\nSuccess rate:70%, weapon attack+2, STR+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043105">
     <string name="name" value="Dark scroll for One-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on one-handed axe.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on one-handed axes.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043106">
     <string name="name" value="Scroll for One-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on the one-handed axe.\nSuccess rate:65%, weapon attack+2, STR+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed axes.\nSuccess rate:65%, weapon attack+2, STR+1"/>
   </imgdir>
   <imgdir name="2043107">
     <string name="name" value="Scroll for One-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on the one-handed axe.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed axes.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2043108">
     <string name="name" value="[4yrAnniv]Scroll for One-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on the Maple Steel Axe. nSuccess rate:40%, weapon attack+3, STR+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Steel Axe.\nSuccess rate:40%, weapon attack+3, STR+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2043110">
     <string name="name" value="Scroll for One-Handed Axe for Accuracy 100%"/>
-    <string name="desc" value="Improves accuracy on one-handed axe.\nSuccess rate:100%, accuracy+1"/>
+    <string name="desc" value="Improves accuracy on one-handed axes.\nSuccess rate:100%, accuracy+1"/>
   </imgdir>
   <imgdir name="2043111">
     <string name="name" value="Scroll for One-Handed Axe for Accuracy 70%"/>
-    <string name="desc" value="Improves accuracy on one-handed axe.\nSuccess rate:70%, accuracy+3, DEX+2, weapon att.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on one-handed axes.\nSuccess rate:70%, accuracy+3, DEX+2, weapon attack+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043112">
     <string name="name" value="Scroll for One-Handed Axe for Accuracy 60%"/>
-    <string name="desc" value="Improves accuracy on one-handed axe.\nSuccess rate:60%, accuracy+3, DEX+2, weapon att.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on one-handed axes.\nSuccess rate:60%, accuracy+3, DEX+2, weapon attack+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043113">
     <string name="name" value="Scroll for One-Handed Axe for Accuracy 30%"/>
-    <string name="desc" value="Improves accuracy on one-handed axe.\nSuccess rate:30%, accuracy+5, DEX+3, weapon att.+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on one-handed axes.\nSuccess rate:30%, accuracy+5, DEX+3, weapon attack+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043114">
     <string name="name" value="Scroll for One-Handed Axe for Accuracy 10%"/>
-    <string name="desc" value="Improves accuracy on one-handed axe.\nSuccess rate:10%, accuracy+5, DEX+3, weapon att.+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on one-handed axes.\nSuccess rate:10%, accuracy+5, DEX+3, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043200">
     <string name="name" value="Scroll for One-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on one-handed blunt weapon.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed blunt weapons.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2043201">
     <string name="name" value="Scroll for One-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on one-handed blunt weapon.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on one-handed blunt weapons.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043202">
     <string name="name" value="Scroll for One-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on one-handed blunt weapon.\nSuccess rate: 10%, weapon attack +5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on one-handed blunt weapons.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043203">
     <string name="name" value="Scroll for One-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on one-handed blunt weaponnSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed blunt weapons.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2043204">
     <string name="name" value="Dark scroll for One-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on one-handed blunt weapon.\nSuccess rate:70%, weapon attack+2, STR+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on one-handed blunt weapons.\nSuccess rate:70%, weapon attack+2, STR+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043205">
     <string name="name" value="Dark scroll for One-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on one-handed blunt weapon.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on one-handed blunt weapons.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043206">
     <string name="name" value="Scroll for One-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on the one-handed blunt weapon.\nSuccess rate:65%, weapon attack+2, STR+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed blunt weapons.\nSuccess rate:65%, weapon attack+2, STR+1"/>
   </imgdir>
   <imgdir name="2043207">
     <string name="name" value="Scroll for One-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on the one-handed blunt weapon.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed blunt weapons.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2043208">
     <string name="name" value="[4yrAnniv]Scroll for One-Handed BW for ATT"/>
-    <string name="desc" value="Added attack upgrade option for the Maple Havoc Hammer. nSuccess rate:40%, weapon attack+3, STR+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Havoc Hammer.\nSuccess rate:40%, weapon attack+3, STR+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2043210">
     <string name="name" value="Scroll for One-Handed BW for Accuracy 100%"/>
-    <string name="desc" value="Improves accuracy on one-handed blunt weapon.\nSuccess rate:100%, accuracy+1"/>
+    <string name="desc" value="Improves accuracy on one-handed blunt weapons.\nSuccess rate:100%, accuracy+1"/>
   </imgdir>
   <imgdir name="2043211">
     <string name="name" value="Scroll for One-Handed BW for Accuracy 70%"/>
-    <string name="desc" value="Improves accuracy on one-handed blunt weapon.\nSuccess rate:70%, accuracy+3, DEX+2, weapon att.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on one-handed blunt weapons.\nSuccess rate:70%, accuracy+3, DEX+2, weapon attack+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043212">
     <string name="name" value="Scroll for One-Handed BW for Accuracy 60%"/>
-    <string name="desc" value="Improves accuracy on one-handed blunt weapon.\nSuccess rate:60%, accuracy+3, DEX+2, weapon att.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on one-handed blunt weapons.\nSuccess rate:60%, accuracy+3, DEX+2, weapon attack+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043213">
     <string name="name" value="Scroll for One-Handed BW for Accuracy 30%"/>
-    <string name="desc" value="Improves accuracy on one-handed blunt weapon.\nSuccess rate:30%, accuracy+5, DEX+3, weapon att.+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on one-handed blunt weapons.\nSuccess rate:30%, accuracy+5, DEX+3, weapon attack+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043214">
     <string name="name" value="Scroll for One-Handed BW for Accuracy 10%"/>
-    <string name="desc" value="Improves accuracy on one-handed blunt weapon.\nSuccess rate:10%, accuracy+5, DEX+3, weapon att.+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on one-handed blunt weapons.\nSuccess rate:10%, accuracy+5, DEX+3, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043300">
     <string name="name" value="Scroll for Dagger for ATT"/>
-    <string name="desc" value="Improves attack on dagger.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on daggers.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2043301">
     <string name="name" value="Scroll for Dagger for ATT"/>
-    <string name="desc" value="Improves attack on dagger.\nSuccess rate:60%, weapon attack+2, LUK+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on daggers.\nSuccess rate:60%, weapon attack+2, LUK+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043302">
     <string name="name" value="Scroll for Dagger for ATT"/>
-    <string name="desc" value="Improves attack on dagger.\nSuccess rate: 10%, weapon attack +5, LUK+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on daggers.\nSuccess rate:10%, weapon attack+5, LUK+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043303">
     <string name="name" value="Scroll for Dagger for ATT"/>
-    <string name="desc" value="Improves attack on dagger.\nSuccess rate:100%, weapon attack+5, LUK+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on daggers.\nSuccess rate:100%, weapon attack+5, LUK+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2043304">
     <string name="name" value="Dark scroll for Dagger for ATT"/>
-    <string name="desc" value="Improves attack on dagger.\nSuccess rate:70%, weapon attack +2, LUK +1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on daggers.\nSuccess rate:70%, weapon attack+2, LUK+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043305">
     <string name="name" value="Dark scroll for Dagger for ATT"/>
-    <string name="desc" value="Improves attack on dagger.\nSuccess rate:30%, weapon attack +5, LUK +3, weapon def. +1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on daggers.\nSuccess rate:30%, weapon attack+5, LUK+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043306">
     <string name="name" value="Scroll for Dagger for ATT"/>
-    <string name="desc" value="Improves attack on the dagger.\nSuccess rate:65%, weapon attack+2, LUK+1"/>
+    <string name="desc" value="Improves weapon attack on daggers.\nSuccess rate:65%, weapon attack+2, LUK+1"/>
   </imgdir>
   <imgdir name="2043307">
     <string name="name" value="Scroll for Dagger for ATT"/>
-    <string name="desc" value="Improves attack on the dagger.\nSuccess rate:15%, weapon attack+5, LUK+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on daggers.\nSuccess rate:15%, weapon attack+5, LUK+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2043308">
     <string name="name" value="[4yrAnniv]Scroll for Dagger for ATT"/>
-    <string name="desc" value="Improves attack on the Maple Dark Mate and Maple Asura DaggernSuccess rate:40%, weapon attack+3, LUK+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Dark Mate and Maple Asura Dagger.\nSuccess rate:40%, weapon attack+3, LUK+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2043700">
     <string name="name" value="Scroll for Wand for Magic Att."/>
-    <string name="desc" value="Improves magic on wand.\nSuccess rate:100%, magic attack+1"/>
+    <string name="desc" value="Improves magic attack on wands.\nSuccess rate:100%, magic attack+1"/>
   </imgdir>
   <imgdir name="2043701">
     <string name="name" value="Scroll for Wand for Magic Att."/>
-    <string name="desc" value="Improves magic on wand.\nSuccess rate:60%, magic attack+2, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic attack on wands.\nSuccess rate:60%, magic attack+2, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043702">
     <string name="name" value="Scroll for Wand for Magic Att."/>
-    <string name="desc" value="Improves magic on wand.\nSuccess rate:10%, magic attack+5, INT+3, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic attack on wands.\nSuccess rate:10%, magic attack+5, INT+3, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043703">
     <string name="name" value="Scroll for Wand for Magic Att."/>
-    <string name="desc" value="Improves magic on wand.\nSuccess rate:100%, magic attack+5, INT+3, magic def.+1"/>
+    <string name="desc" value="Improves magic attack on wands.\nSuccess rate:100%, magic attack+5, INT+3, magic def.+1"/>
   </imgdir>
   <imgdir name="2043704">
     <string name="name" value="Dark scroll for Wand for Magic Att."/>
-    <string name="desc" value="Improves magic on wand.\nSuccess rate:70%, magic attack+2, INT+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic attack on wands.\nSuccess rate:70%, magic attack+2, INT+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043705">
     <string name="name" value="Dark scroll for Wand for Magic Att."/>
-    <string name="desc" value="Improves magic on wand.\nSuccess rate:30%, magic attack+5, INT+3, magic def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic attack on wands.\nSuccess rate:30%, magic attack+5, INT+3, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043706">
     <string name="name" value="Scroll for Wand for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the wand.\nSuccess rate:65%, magic attack+2, INT+1"/>
+    <string name="desc" value="Improves magic attack on wands.\nSuccess rate:65%, magic attack+2, INT+1"/>
   </imgdir>
   <imgdir name="2043707">
     <string name="name" value="Scroll for Wand for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the wand.\nSuccess rate:15%, magic attack+5, INT+3, magic def.+1"/>
+    <string name="desc" value="Improves magic attack on wands.\nSuccess rate:15%, magic attack+5, INT+3, magic def.+1"/>
   </imgdir>
   <imgdir name="2043708">
     <string name="name" value="[4yrAnniv]Scroll for Wand for Magic Att."/>
-    <string name="desc" value="Improves magic attack on Maple Shine Wand.\nSuccess rate:40%, magic attack+3, INT+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves magic attack on the Maple Shine Wand.\nSuccess rate:40%, magic attack+3, INT+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2043800">
     <string name="name" value="Scroll for Staff for Magic Att."/>
-    <string name="desc" value="Improves magic on staff.\nSuccess rate:100%, magic attack+1"/>
+    <string name="desc" value="Improves magic attack on staffs.\nSuccess rate:100%, magic attack+1"/>
   </imgdir>
   <imgdir name="2043801">
     <string name="name" value="Scroll for Staff for Magic Att."/>
-    <string name="desc" value="Improves magic on staff.\nSuccess rate:60%, magic attack+2, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic attack on staffs.\nSuccess rate:60%, magic attack+2, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043802">
     <string name="name" value="Scroll for Staff for Magic Att."/>
-    <string name="desc" value="Improves magic on staff.\nSuccess rate:10%, magic attack+5, INT+3, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves magic attack on staffs.\nSuccess rate:10%, magic attack+5, INT+3, magic def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043803">
     <string name="name" value="Scroll for Staff for Magic Att."/>
-    <string name="desc" value="Improves magic on staff.\nSuccess rate:100%, magic attack+5, INT+3, magic def.+1"/>
+    <string name="desc" value="Improves magic attack on staffs.\nSuccess rate:100%, magic attack+5, INT+3, magic def.+1"/>
   </imgdir>
   <imgdir name="2043804">
     <string name="name" value="Dark scroll for Staff for Magic Att."/>
-    <string name="desc" value="Improves magic on staff.\nSuccess rate:70%, magic attack+2, INT+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic attack on staffs.\nSuccess rate:70%, magic attack+2, INT+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043805">
     <string name="name" value="Dark scroll for Staff for Magic Att."/>
-    <string name="desc" value="Improves magic on staff.\nSuccess rate:30%, magic attack+5, INT+3, magic def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves magic attack on staffs.\nSuccess rate:30%, magic attack+5, INT+3, magic def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2043806">
     <string name="name" value="Scroll for Staff for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the staff.\nSuccess rate:65%, magic attack+2, INT+1"/>
+    <string name="desc" value="Improves magic attack on staffs.\nSuccess rate:65%, magic attack+2, INT+1"/>
   </imgdir>
   <imgdir name="2043807">
     <string name="name" value="Scroll for Staff for Magic Att."/>
-    <string name="desc" value="Improves magic attack on the staff.\nSuccess rate:15%, magic attack+5, INT+3, magic def.+1"/>
+    <string name="desc" value="Improves magic attack on staffs.\nSuccess rate:15%, magic attack+5, INT+3, magic def.+1"/>
   </imgdir>
   <imgdir name="2043808">
     <string name="name" value="[4yrAnniv]Scroll for Staff for Magic Att."/>
-    <string name="desc" value="Improves magic attack on Maple Wisdom Staff.\nSuccess rate:40%, magic attack+3, INT+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves magic attack on the Maple Wisdom Staff.\nSuccess rate:40%, magic attack+3, INT+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2044000">
     <string name="name" value="Scroll for Two-handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on two-handed sword.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044001">
     <string name="name" value="Scroll for Two-handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on two-handed sword.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044002">
     <string name="name" value="Scroll for Two-handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on two-handed sword.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044003">
     <string name="name" value="Scroll for Two-handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on two-handed sword weapon.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044004">
     <string name="name" value="Dark scroll for Two-handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on two-handed sword.\nSuccess rate:70%, weapon attack+2, STR+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:70%, weapon attack+2, STR+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044005">
     <string name="name" value="Dark scroll for Two-handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on two-handed sword.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044006">
     <string name="name" value="Scroll for Two-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on the two-handed sword.\nSuccess rate:65%, weapon attack+2, STR+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:65%, weapon attack+2, STR+1"/>
   </imgdir>
   <imgdir name="2044007">
     <string name="name" value="Scroll for Two-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack on the two-handed sword.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044008">
     <string name="name" value="[4yrAnniv]Scroll for Two-Handed Sword for ATT"/>
-    <string name="desc" value="Improves attack for Maple Soul Rohen. nSuccess rate:40%, weapon attack+3, STR+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Soul Rohen.\nSuccess rate:40%, weapon attack+3, STR+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2044010">
     <string name="name" value="Scroll for Two-Handed Sword for Accuracy 100%"/>
@@ -3133,167 +3133,167 @@
   </imgdir>
   <imgdir name="2044011">
     <string name="name" value="Scroll for Two-Handed Sword for Accuracy 70%"/>
-    <string name="desc" value="Improves accuracy on two-handed swords.\nSuccess rate:70%, accuracy+3, DEX+2, weapon att.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on two-handed swords.\nSuccess rate:70%, accuracy+3, DEX+2, weapon attack+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044012">
     <string name="name" value="Scroll for Two-Handed Sword for Accuracy 60%"/>
-    <string name="desc" value="Improves accuracy on two-handed swords.\nSuccess rate:60%, accuracy+3, DEX+2, weapon att.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on two-handed swords.\nSuccess rate:60%, accuracy+3, DEX+2, weapon attack+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044013">
     <string name="name" value="Scroll for Two-Handed Sword for Accuracy 30%"/>
-    <string name="desc" value="Improves accuracy on two-handed swords.\nSuccess rate:30%, accuracy+5, DEX+3, weapon att.+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on two-handed swords.\nSuccess rate:30%, accuracy+5, DEX+3, weapon attack+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044014">
     <string name="name" value="Scroll for Two-Handed Sword for Accuracy 10%"/>
-    <string name="desc" value="Improves accuracy on two-handed swords.\nSuccess rate:10%, accuracy+5, DEX+3, weapon att.+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on two-handed swords.\nSuccess rate:10%, accuracy+5, DEX+3, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044100">
     <string name="name" value="Scroll for Two-handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on two-handed axe.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed axes.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044101">
     <string name="name" value="Scroll for Two-handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on two-handed axe.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on two-handed axes.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044102">
     <string name="name" value="Scroll for Two-handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on two-handed axe.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def. +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on two-handed axes.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044103">
     <string name="name" value="Scroll for Two-handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on two-handed axe.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed axes.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044104">
     <string name="name" value="Dark scroll for Two-handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on two-handed axe.\nSuccess rate:70%, weapon attack+2, STR+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on two-handed axes.\nSuccess rate:70%, weapon attack+2, STR+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044105">
     <string name="name" value="Dark scroll for Two-handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on two-handed axe.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on two-handed axes.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044106">
     <string name="name" value="Scroll for Two-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on the two-handed axe.\nSuccess rate:65%, weapon attack+2, STR+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed axes.\nSuccess rate:65%, weapon attack+2, STR+1"/>
   </imgdir>
   <imgdir name="2044107">
     <string name="name" value="Scroll for Two-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack on the two-handed axe.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed axes.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044108">
     <string name="name" value="[4yrAnniv]Scroll for Two-Handed Axe for ATT"/>
-    <string name="desc" value="Improves attack for Maple Demon Axe. nSuccess rate:40%, weapon attack+3, STR+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Demon Axe.\nSuccess rate:40%, weapon attack+3, STR+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2044110">
     <string name="name" value="Scroll for Two-Handed Axe for Accuracy 100%"/>
-    <string name="desc" value="Improves accuracy on two-handed axe.\nSuccess rate:100%, accuracy+1"/>
+    <string name="desc" value="Improves accuracy on two-handed axes.\nSuccess rate:100%, accuracy+1"/>
   </imgdir>
   <imgdir name="2044111">
     <string name="name" value="Scroll for Two-Handed Axe for Accuracy 70%"/>
-    <string name="desc" value="Improves accuracy on two-handed axe.\nSuccess rate:70%, accuracy+3, DEX+2, weapon att.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on two-handed axes.\nSuccess rate:70%, accuracy+3, DEX+2, weapon attack+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044112">
     <string name="name" value="Scroll for Two-Handed Axe for Accuracy 60%"/>
-    <string name="desc" value="Improves accuracy on two-handed axe.\nSuccess rate:60%, accuracy+3, DEX+2, weapon att.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on two-handed axes.\nSuccess rate:60%, accuracy+3, DEX+2, weapon attack+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044113">
     <string name="name" value="Scroll for Two-Handed Axe for Accuracy 30%"/>
-    <string name="desc" value="Improves accuracy on two-handed axe.\nSuccess rate:30%, accuracy+5, DEX+3, weapon att.+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on two-handed axes.\nSuccess rate:30%, accuracy+5, DEX+3, weapon attack+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044114">
     <string name="name" value="Scroll for Two-Handed Axe for Accuracy 10%"/>
-    <string name="desc" value="Improves accuracy on two-handed axe.\nSuccess rate:10%, accuracy+5, DEX+3, weapon att.+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on two-handed axes.\nSuccess rate:10%, accuracy+5, DEX+3, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044200">
     <string name="name" value="Scroll for Two-handed BW for ATT"/>
-    <string name="desc" value="Improves attack on two-handed blunt weapon.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed blunt weapons.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044201">
     <string name="name" value="Scroll for Two-handed BW for ATT"/>
-    <string name="desc" value="Improves attack on two-handed blunt weapon.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on two-handed blunt weapons.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044202">
     <string name="name" value="Scroll for Two-handed BW for ATT"/>
-    <string name="desc" value="Improves attack on two-handed blunt weapon.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on two-handed blunt weapons.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044203">
     <string name="name" value="Scroll for Two-handed BW for ATT"/>
-    <string name="desc" value="Improves attack on two-handed blunt weapon.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed blunt weapons.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044204">
     <string name="name" value="Dark scroll for Two-handed BW for ATT"/>
-    <string name="desc" value="Improves attack on two-handed blunt weapon.\nSuccess rate:70%, weapon attack+2, STR+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on two-handed blunt weapons.\nSuccess rate:70%, weapon attack+2, STR+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044205">
     <string name="name" value="Dark scroll for Two-handed BW for ATT"/>
-    <string name="desc" value="Improves attack on two-handed blunt weapon.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on two-handed blunt weapons.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044206">
     <string name="name" value="Scroll for Two-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on the two-handed blunt weapon.\nSuccess rate:65%, weapon attack+2, STR+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed blunt weapons.\nSuccess rate:65%, weapon attack+2, STR+1"/>
   </imgdir>
   <imgdir name="2044207">
     <string name="name" value="Scroll for Two-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on the two-handed blunt weapon.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed blunt weapons.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044208">
     <string name="name" value="[4yrAnniv]Scroll for Two-Handed BW for ATT"/>
-    <string name="desc" value="Improves attack on Maple Belzet. nSuccess rate:40%, weapon attack+3, STR+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Belzet.\nSuccess rate:40%, weapon attack+3, STR+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2044210">
     <string name="name" value="Scroll for Two-Handed BW for Accuracy 100%"/>
-    <string name="desc" value="Improves accuracy on two-handed blunt weapon.\nSuccess rate:100%, accuracy+1"/>
+    <string name="desc" value="Improves accuracy on two-handed blunt weapons.\nSuccess rate:100%, accuracy+1"/>
   </imgdir>
   <imgdir name="2044211">
     <string name="name" value="Scroll for Two-Handed BW for Accuracy 70%"/>
-    <string name="desc" value="Improves accuracy on two-handed blunt weapon.\nSuccess rate:70%, accuracy+3, DEX+2, weapon att.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on two-handed blunt weapons.\nSuccess rate:70%, accuracy+3, DEX+2, weapon attack+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044212">
     <string name="name" value="Scroll for Two-Handed BW for Accuracy 60%"/>
-    <string name="desc" value="Improves accuracy on two-handed blunt weapon.\nSuccess rate:60%, accuracy+3, DEX+2, weapon att.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on two-handed blunt weapons.\nSuccess rate:60%, accuracy+3, DEX+2, weapon attack+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044213">
     <string name="name" value="Scroll for Two-Handed BW for Accuracy 30%"/>
-    <string name="desc" value="Improves accuracy on two-handed blunt weapon.\nSuccess rate:30%, accuracy+5, DEX+3, weapon att.+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on two-handed blunt weapons.\nSuccess rate:30%, accuracy+5, DEX+3, weapon attack+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044214">
     <string name="name" value="Scroll for Two-Handed BW for Accuracy 10%"/>
-    <string name="desc" value="Improves accuracy on two-handed blunt weapon.\nSuccess rate:10%, accuracy+5, DEX+3, weapon att.+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on two-handed blunt weapons.\nSuccess rate:10%, accuracy+5, DEX+3, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044300">
     <string name="name" value="Scroll for Spear for ATT"/>
-    <string name="desc" value="Improves attack on spear.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on spears.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044301">
     <string name="name" value="Scroll for Spear for ATT"/>
-    <string name="desc" value="Improves attack on spear.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on spears.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044302">
     <string name="name" value="Scroll for Spear for ATT"/>
-    <string name="desc" value="Improves attack on spear.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on spears.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044303">
     <string name="name" value="Scroll for Spear for ATT"/>
-    <string name="desc" value="Improves attack on spear.\nSuccess rate:100%, weapon attack +5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on spears.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044304">
     <string name="name" value="Dark scroll for Spear for ATT"/>
-    <string name="desc" value="Improves attack on spear.\nSuccess rate:70%, weapon attack +2, STR+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on spears.\nSuccess rate:70%, weapon attack+2, STR+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044305">
     <string name="name" value="Dark scroll for Spear for ATT"/>
-    <string name="desc" value="Improves attack on spear.\nSuccess rate:30%, weapon attack +5, STR+3, weapon def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on spears.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044306">
     <string name="name" value="Scroll for Spear for ATT"/>
-    <string name="desc" value="Improves attack on the Spear. nSuccess rate:65%, weapon attack+2, STR+1"/>
+    <string name="desc" value="Improves weapon attack on spears.\nSuccess rate:65%, weapon attack+2, STR+1"/>
   </imgdir>
   <imgdir name="2044307">
     <string name="name" value="Scroll for Spear for ATT"/>
-    <string name="desc" value="Improves attack on the Spear. nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on spears.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044308">
     <string name="name" value="[4yrAnniv]Scroll for Spear for ATT"/>
-    <string name="desc" value="Improves attack on Maple Soul Spear. nSuccess rate:40%, weapon attack+3, STR+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Soul Spear.\nSuccess rate:40%, weapon attack+3, STR+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2044310">
     <string name="name" value="Scroll for Spear for Accuracy 100%"/>
@@ -3301,203 +3301,203 @@
   </imgdir>
   <imgdir name="2044311">
     <string name="name" value="Scroll for Spear for Accuracy 70%"/>
-    <string name="desc" value="Improves accuracy on spears.\nSuccess rate:70%, accuracy+3, DEX+2, weapon att.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on spears.\nSuccess rate:70%, accuracy+3, DEX+2, weapon attack+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044312">
     <string name="name" value="Scroll for Spear for Accuracy 60%"/>
-    <string name="desc" value="Improves accuracy on spears.\nSuccess rate:60%, accuracy+3, DEX+2, weapon att.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on spears.\nSuccess rate:60%, accuracy+3, DEX+2, weapon attack+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044313">
     <string name="name" value="Scroll for Spear for Accuracy 30%"/>
-    <string name="desc" value="Improves accuracy on spears.\nSuccess rate:30%, accuracy+5, DEX+3, weapon att.+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on spears.\nSuccess rate:30%, accuracy+5, DEX+3, weapon attack+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044314">
     <string name="name" value="Scroll for Spear for Accuracy 10%"/>
-    <string name="desc" value="Improves accuracy on spears.\nSuccess rate:10%, accuracy+5, DEX+3, weapon att.+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on spears.\nSuccess rate:10%, accuracy+5, DEX+3, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044400">
     <string name="name" value="Scroll for Pole Arm for ATT"/>
-    <string name="desc" value="Improves attack on pole arm.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on pole arms.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044401">
     <string name="name" value="Scroll for Pole Arm for ATT"/>
-    <string name="desc" value="Improves attack on pole arm.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on pole arms.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044402">
     <string name="name" value="Scroll for Pole Arm for ATT"/>
-    <string name="desc" value="Improves attack on pole arm.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on pole arms.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044403">
     <string name="name" value="Scroll for Pole Arm for ATT"/>
-    <string name="desc" value="Improves attack on pole arm.\nSuccess rate:100%, weapon attack +5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on pole arms.\nSuccess rate:100%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044404">
     <string name="name" value="Dark scroll for Pole Arm for ATT"/>
-    <string name="desc" value="Improves attack on pole arm.\nSuccess rate:70%, weapon attack +2, STR+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on pole arms.\nSuccess rate:70%, weapon attack+2, STR+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044405">
     <string name="name" value="Dark scroll for Pole Arm for ATT"/>
-    <string name="desc" value="Improves attack on pole arm.\nSuccess rate:30%, weapon attack +5, STR+3, weapon def.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on pole arms.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044406">
     <string name="name" value="Scroll for Pole Arm for ATT"/>
-    <string name="desc" value="Improves attack on the Pole arm. nSuccess rate:65%, weapon attack+2, STR+1"/>
+    <string name="desc" value="Improves weapon attack on pole arms.\nSuccess rate:65%, weapon attack+2, STR+1"/>
   </imgdir>
   <imgdir name="2044407">
     <string name="name" value="Scroll for Pole Arm for ATT"/>
-    <string name="desc" value="Improves attack on the Pole arm. nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
+    <string name="desc" value="Improves weapon attack on pole arms.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044408">
     <string name="name" value="[4yrAnniv]Scroll for Pole Arm for ATT"/>
-    <string name="desc" value="Improves attack for Maple Karstan nSuccess rate:40%, weapon attack+3, STR+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Karstan.\nSuccess rate:40%, weapon attack+3, STR+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2044410">
     <string name="name" value="Scroll for Pole-Arm for Accuracy 100%"/>
-    <string name="desc" value="Improves accuracy on pole-arms.\nSuccess rate:100%, accuracy+1"/>
+    <string name="desc" value="Improves accuracy on pole arms.\nSuccess rate:100%, accuracy+1"/>
   </imgdir>
   <imgdir name="2044411">
     <string name="name" value="Scroll for Pole-Arm for Accuracy 70%"/>
-    <string name="desc" value="Improves accuracy on pole-arms.\nSuccess rate:70%, accuracy+3, DEX+2, weapon att.+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on pole arms.\nSuccess rate:70%, accuracy+3, DEX+2, weapon attack+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044412">
     <string name="name" value="Scroll for Pole-Arm for Accuracy 60%"/>
-    <string name="desc" value="Improves accuracy on pole-arms.\nSuccess rate:60%, accuracy+3, DEX+2, weapon att.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on pole arms.\nSuccess rate:60%, accuracy+3, DEX+2, weapon attack+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044413">
     <string name="name" value="Scroll for Pole-Arm for Accuracy 30%"/>
-    <string name="desc" value="Improves accuracy on pole-arms.\nSuccess rate:30%, accuracy+5, DEX+3, weapon att.+3nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves accuracy on pole arms.\nSuccess rate:30%, accuracy+5, DEX+3, weapon attack+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044414">
     <string name="name" value="Scroll for Pole-Arm for Accuracy 10%"/>
-    <string name="desc" value="Improves accuracy on pole-arms.\nSuccess rate:10%, accuracy+5, DEX+3, weapon att.+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on pole arms.\nSuccess rate:10%, accuracy+5, DEX+3, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044500">
     <string name="name" value="Scroll for Bow for ATT"/>
-    <string name="desc" value="Improves attack on bow.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on bows.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044501">
     <string name="name" value="Scroll for Bow for ATT"/>
-    <string name="desc" value="Improves attack on bow.\nSuccess rate: 60%, weapon attack+2, accuracy +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on bows.\nSuccess rate:60%, weapon attack+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044502">
     <string name="name" value="Scroll for Bow for ATT"/>
-    <string name="desc" value="Improves attack on bow.\nSuccess rate:10%, weapon attack+5, accuracy+3, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on bows.\nSuccess rate:10%, weapon attack+5, accuracy+3, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044503">
     <string name="name" value="Scroll for Bow for ATT"/>
-    <string name="desc" value="Improves attack on bow.\nSuccess rate:100%, weapon attack +5, accuracy +3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on bows.\nSuccess rate:100%, weapon attack+5, accuracy+3, DEX+1"/>
   </imgdir>
   <imgdir name="2044504">
     <string name="name" value="Dark scroll for Bow for ATT"/>
-    <string name="desc" value="Improves attack on bow.\nSuccess rate:70%, weapon attack +2, accuracy +1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on bows.\nSuccess rate:70%, weapon attack+2, accuracy+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044505">
     <string name="name" value="Dark scroll for Bow for ATT"/>
-    <string name="desc" value="Improves attack on bow.\nSuccess rate:30%, weapon attack +5, accuracy +3, DEX+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on bows.\nSuccess rate:30%, weapon attack+5, accuracy+3, DEX+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044506">
     <string name="name" value="Scroll for Bow for ATT"/>
-    <string name="desc" value="Improves attack on the Bow. nSuccess rate:65%, weapon attack+2, accuracy+1"/>
+    <string name="desc" value="Improves weapon attack on bows.\nSuccess rate:65%, weapon attack+2, accuracy+1"/>
   </imgdir>
   <imgdir name="2044507">
     <string name="name" value="Scroll for Bow for ATT"/>
-    <string name="desc" value="Improves attack on the Bow. nSuccess rate:15%, weapon attack+5, accuracy+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on bows.\nSuccess rate:15%, weapon attack+5, accuracy+3, DEX+1"/>
   </imgdir>
   <imgdir name="2044508">
     <string name="name" value="[4yrAnniv]Scroll for Bow for ATT"/>
-    <string name="desc" value="Improves attack on Maple Kandiva Bow. nSuccess rate:40%, weapon attack+3, accuracy+1nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Kandiva Bow.\nSuccess rate:40%, weapon attack+3, accuracy+1.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2044600">
     <string name="name" value="Scroll for Crossbow for ATT"/>
-    <string name="desc" value="Improves attack on crossbow.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on crossbows.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044601">
     <string name="name" value="Scroll for Crossbow for ATT"/>
-    <string name="desc" value="Improves attack on crossbow.\nSuccess rate:60%, weapon attack+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on crossbows.\nSuccess rate:60%, weapon attack+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044602">
     <string name="name" value="Scroll for Crossbow for ATT"/>
-    <string name="desc" value="Improves attack on crossbow.\nSuccess rate:10%, weapon attack+5, accuracy+3, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on crossbows.\nSuccess rate:10%, weapon attack+5, accuracy+3, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044603">
     <string name="name" value="Scroll for Crossbow for ATT"/>
-    <string name="desc" value="Improves attack on crossbow.\nSuccess rate:100%, weapon attack+5, accuracy+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on crossbows.\nSuccess rate:100%, weapon attack+5, accuracy+3, DEX+1"/>
   </imgdir>
   <imgdir name="2044604">
     <string name="name" value="Dark scroll for Crossbow for ATT"/>
-    <string name="desc" value="Improves attack on crossbow.\nSuccess rate:70%, weapon attack+2, accuracy+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on crossbows.\nSuccess rate:70%, weapon attack+2, accuracy+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044605">
     <string name="name" value="Dark scroll for Crossbow for ATT"/>
-    <string name="desc" value="Improves attack on crossbow.\nSuccess rate:30%, weapon attack+5, accuracy+3, DEX+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on crossbows.\nSuccess rate:30%, weapon attack+5, accuracy+3, DEX+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044606">
     <string name="name" value="Scroll for Crossbow for ATT"/>
-    <string name="desc" value="Improves attack on the Crossbow. nSuccess rate:65%, weapon attack+2, accuracy+1"/>
+    <string name="desc" value="Improves weapon attack on crossbows.\nSuccess rate:65%, weapon attack+2, accuracy+1"/>
   </imgdir>
   <imgdir name="2044607">
     <string name="name" value="Scroll for Crossbow for ATT"/>
-    <string name="desc" value="Improves attack on the Crossbow. nSuccess rate:15%, weapon attack+5, accuracy+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on crossbows.\nSuccess rate:15%, weapon attack+5, accuracy+3, DEX+1"/>
   </imgdir>
   <imgdir name="2044608">
     <string name="name" value="[4yrAnniv]Scroll for Crossbow for ATT"/>
-    <string name="desc" value="Improves attack on Maple Nishada. nSuccess rate:40%, weapon attack+3, accuracy+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Nishada.\nSuccess rate:40%, weapon attack+3, accuracy+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2044700">
     <string name="name" value="Scroll for Claw for ATT"/>
-    <string name="desc" value="Improves attack on claw.\nSuccess rate:100%, weapon attack+1"/>
+    <string name="desc" value="Improves weapon attack on claws.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044701">
     <string name="name" value="Scroll for Claw for ATT"/>
-    <string name="desc" value="Improves attack on claw.\nSuccess rate:60%, weapon attack+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on claws.\nSuccess rate:60%, weapon attack+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044702">
     <string name="name" value="Scroll for Claw for ATT"/>
-    <string name="desc" value="Improves attack on claw.\nSuccess rate:10%, weapon attack+5, accuracy+3, LUK+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on claws.\nSuccess rate:10%, weapon attack+5, accuracy+3, LUK+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044703">
     <string name="name" value="Scroll for Claw for ATT"/>
-    <string name="desc" value="Improves attack on claw.\nSuccess rate:100%, weapon attack+5, accuracy+3, LUK+1"/>
+    <string name="desc" value="Improves weapon attack on claws.\nSuccess rate:100%, weapon attack+5, accuracy+3, LUK+1"/>
   </imgdir>
   <imgdir name="2044704">
     <string name="name" value="Dark Scroll for Claw for ATT"/>
-    <string name="desc" value="Improves attack on claw.\nSuccess rate:70%, weapon attack +2, accuracy +1nIf failed, the item will be destroyed at the 50% rate."/>
+    <string name="desc" value="Improves weapon attack on claws.\nSuccess rate:70%, weapon attack+2, accuracy+1.\nIf failed, the item will be destroyed at the 50% rate."/>
   </imgdir>
   <imgdir name="2044705">
     <string name="name" value="Dark scroll for Claw for ATT"/>
-    <string name="desc" value="Improves attack on claw.\nSuccess rate:30%, weapon attack +5, accuracy +3, LUK+1nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves weapon attack on claws.\nSuccess rate:30%, weapon attack+5, accuracy+3, LUK+1.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044706">
     <string name="name" value="Scroll for Claw for ATT"/>
-    <string name="desc" value="Improves attack on the Claw. nSuccess rate:65%, weapon attack+2, accuracy+1"/>
+    <string name="desc" value="Improves weapon attack on claws.\nSuccess rate:65%, weapon attack+2, accuracy+1"/>
   </imgdir>
   <imgdir name="2044707">
     <string name="name" value="Scroll for Claw for ATT"/>
-    <string name="desc" value="Improves attack on the Claw. nSuccess rate:15%, weapon attack+5, accuracy+3, LUK+1"/>
+    <string name="desc" value="Improves weapon attack on claws.\nSuccess rate:15%, weapon attack+5, accuracy+3, LUK+1"/>
   </imgdir>
   <imgdir name="2044708">
     <string name="name" value="[4yrAnniv]Scroll for Claw for ATT"/>
-    <string name="desc" value="Improves attack on Maple Scandar. nSuccess rate:40%, weapon attack+3, accuracy+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Skanda.\nSuccess rate:40%, weapon attack+3, accuracy+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2044800">
     <string name="name" value="Scroll for Knuckler for Attack 100%"/>
-    <string name="desc" value="Improves attack on Knucklers.\nSuccess rate:100%, weapon att. +1"/>
+    <string name="desc" value="Improves weapon attack on knuckles.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044801">
     <string name="name" value="Scroll for Knuckler for Attack 60%"/>
-    <string name="desc" value="Improves attack on Knucklers.\nSuccess rate:60%, weapon att. +2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on knuckles.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044802">
     <string name="name" value="Scroll for Knuckler for ATT"/>
-    <string name="desc" value="Improves attack on Knucklers.\nSuccess rate:10%, weapon att. +5, STR+3, weapon def. +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on knuckles.\nSuccess rate:10%, weapon attack+5, STR+3, weapon def.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044803">
     <string name="name" value="Scroll for Knuckler for Attack 70%"/>
-    <string name="desc" value="Improves attack on Knucklers.\nSuccess rate:70%, weapon att. +2, STR+1nIf failed, the item will be destroyed at a 50% rate"/>
+    <string name="desc" value="Improves weapon attack on knuckles.\nSuccess rate:70%, weapon attack+2, STR+1.\nIf failed, the item will be destroyed at a 50% rate"/>
   </imgdir>
   <imgdir name="2044804">
     <string name="name" value="Scroll for Knuckler for Attack 30%"/>
-    <string name="desc" value="Improves attack on Knucklers.\nSuccess rate:30%, weapon att. +5, STR+3, weapon def. +1nIf failed, the item will be destroyed at a 50% rate"/>
+    <string name="desc" value="Improves weapon attack on knuckles.\nSuccess rate:30%, weapon attack+5, STR+3, weapon def.+1.\nIf failed, the item will be destroyed at a 50% rate"/>
   </imgdir>
   <imgdir name="2044805">
     <string name="name" value="Scroll for Knuckle for Accuracy 100%"/>
@@ -3505,47 +3505,47 @@
   </imgdir>
   <imgdir name="2044806">
     <string name="name" value="Scroll for Knuckle for Accuracy 70%"/>
-    <string name="desc" value="Improves accuracy on knuckles.\nSuccess rate:70%, accuracy+3, DEX+2, weapon att.+1nIf failed, the item will be destroyed at a 50% rate.."/>
+    <string name="desc" value="Improves accuracy on knuckles.\nSuccess rate:70%, accuracy+3, DEX+2, weapon attack+1.\nIf failed, the item will be destroyed at a 50% rate.."/>
   </imgdir>
   <imgdir name="2044807">
     <string name="name" value="Scroll for Knuckle for Accuracy 60%"/>
-    <string name="desc" value="Improves accuracy on knuckles.\nSuccess rate:60%, accuracy+3, DEX+2, weapon att.+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on knuckles.\nSuccess rate:60%, accuracy+3, DEX+2, weapon attack+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044808">
     <string name="name" value="Scroll for Knuckle for Accuracy 30%"/>
-    <string name="desc" value="Improves accuracy on knuckles.\nSuccess rate:30%, accuracy+5, DEX+3, weapon att.+3nIf failed, the item will be destroyed at a 50% rate.."/>
+    <string name="desc" value="Improves accuracy on knuckles.\nSuccess rate:30%, accuracy+5, DEX+3, weapon attack+3.\nIf failed, the item will be destroyed at a 50% rate.."/>
   </imgdir>
   <imgdir name="2044809">
     <string name="name" value="Scroll for Knuckle for Accuracy 10%"/>
-    <string name="desc" value="Improves accuracy on knuckles.\nSuccess rate:10%, accuracy+5, DEX+3, weapon att.+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves accuracy on knuckles.\nSuccess rate:10%, accuracy+5, DEX+3, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044810">
     <string name="name" value="[4yrAnniv] Scroll for Knuckle for Attack 40%"/>
-    <string name="desc" value="Improves the attack on Maple Golden Claw. nSuccess rate:40%,weapon att.+3,STR+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Golden Claw.\nSuccess rate:40%, weapon attack+3, STR+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2044900">
     <string name="name" value="Scroll for Gun for Attack 100%"/>
-    <string name="desc" value="Improves attack on Guns.\nSuccess rate:100%, weapon att. +1"/>
+    <string name="desc" value="Improves weapon attack on guns.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044901">
     <string name="name" value="Scroll for Gun for Attack 60%"/>
-    <string name="desc" value="Improves attack on Guns.\nSuccess rate:60%, weapon att. +2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on guns.\nSuccess rate:60%, weapon attack+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044902">
     <string name="name" value="Scroll for Gun for ATT"/>
-    <string name="desc" value="Improves attack on Guns.\nSuccess rate:10%, weapon att. +5, accuracy+3, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on guns.\nSuccess rate:10%, weapon attack+5, accuracy+3, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044903">
     <string name="name" value="Scroll for Gun for Attack 70%"/>
-    <string name="desc" value="Improves attack on Guns.\nSuccess rate:70%, weapon att. +2, accuracy+1nIf failed, the item will be destroyed at a 50% rate"/>
+    <string name="desc" value="Improves weapon attack on guns.\nSuccess rate:70%, weapon attack+2, accuracy+1.\nIf failed, the item will be destroyed at a 50% rate"/>
   </imgdir>
   <imgdir name="2044904">
     <string name="name" value="Scroll for Gun for Attack 30%"/>
-    <string name="desc" value="Improves attack on Guns.\nSuccess rate:30%, weapon att. +5, accuracy+3, DEX+1nIf failed, the item will be destroyed at a 50% rate"/>
+    <string name="desc" value="Improves weapon attack on guns.\nSuccess rate:30%, weapon attack+5, accuracy+3, DEX+1.\nIf failed, the item will be destroyed at a 50% rate"/>
   </imgdir>
   <imgdir name="2044905">
     <string name="name" value="[4yrAnniv] Gun for Attack 40%"/>
-    <string name="desc" value="Improves the attact on Maple Canon Shooter. nSuccess rate:40%, weapon att.+3, accuracy+2nIf failed, the item will be destroyed at a 30% rate."/>
+    <string name="desc" value="Improves weapon attack on the Maple Canon Shooter.\nSuccess rate:40%, weapon attack+3, accuracy+2.\nIf failed, the item will be destroyed at a 30% rate."/>
   </imgdir>
   <imgdir name="2048000">
     <string name="name" value="Scroll for Pet Equip. for Speed"/>
@@ -3553,11 +3553,11 @@
   </imgdir>
   <imgdir name="2048001">
     <string name="name" value="Scroll for Pet Equip. for Speed"/>
-    <string name="desc" value="Improves speed on pet equip.\nSuccess rate:60%, moving speed+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves speed on pet equip.\nSuccess rate:60%, speed+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2048002">
     <string name="name" value="Scroll for Pet Equip. for Speed"/>
-    <string name="desc" value="Improves speed on pet equip.\nSuccess rate:10%, moving speed+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves speed on pet equip.\nSuccess rate:10%, speed+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2048003">
     <string name="name" value="Scroll for Pet Equip. for Jump"/>
@@ -3573,51 +3573,51 @@
   </imgdir>
   <imgdir name="2048006">
     <string name="name" value="Scroll for Pet Equip. for Speed"/>
-    <string name="desc" value="Improves speed on Pet Equip. nSuccess rate:65%, speed+2"/>
+    <string name="desc" value="Improves speed on pet equip.\nSuccess rate:65%, speed+2"/>
   </imgdir>
   <imgdir name="2048007">
     <string name="name" value="Scroll for Pet Equip. for Speed"/>
-    <string name="desc" value="Improves speed on Pet Equip. nSuccess rate:15%, speed+3"/>
+    <string name="desc" value="Improves speed on pet equip.\nSuccess rate:15%, speed+3"/>
   </imgdir>
   <imgdir name="2048008">
     <string name="name" value="Scroll for Pet Equip. for Jump"/>
-    <string name="desc" value="Improves jump on Pet equip. nSuccess rate:65%, jump+2"/>
+    <string name="desc" value="Improves jump on pet equip.\nSuccess rate:65%, jump+2"/>
   </imgdir>
   <imgdir name="2048009">
     <string name="name" value="Scroll for Pet Equip. for Jump"/>
-    <string name="desc" value="Improves jump on Pet equip. nSuccess rate:15%, jump+3"/>
+    <string name="desc" value="Improves jump on pet equip.\nSuccess rate:15%, jump+3"/>
   </imgdir>
   <imgdir name="2048010">
     <string name="name" value="Scroll for Pet Equip. for STR 60%"/>
-    <string name="desc" value="Improves strength on pet equipments.\nSuccess rate:60%, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on pet equip.\nSuccess rate:60%, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2048011">
     <string name="name" value="Scroll for Pet Equip. for INT 60%"/>
-    <string name="desc" value="Improves intelligence on pet equipments.\nSuccess rate:60%, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on pet equip.\nSuccess rate:60%, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2048012">
     <string name="name" value="Scroll for Pet Equip. for DEX 60%"/>
-    <string name="desc" value="Improves dexterity on pet equipments.\nSuccess rate:60%, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on pet equip.\nSuccess rate:60%, DEX+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2048013">
     <string name="name" value="Scroll for Pet Equip. for LUK 60%"/>
-    <string name="desc" value="Improves luck on pet equipments.\nSuccess rate:60%, LUK+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on pet equip.\nSuccess rate:60%, LUK+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2049000">
     <string name="name" value="Clean Slate Scroll 1%"/>
-    <string name="desc" value="Recovers the lost number of upgrades due to failed scroll by 1. Not available on Cash Items. Success rate:1%, If failed, the item will be destroyed at a 2% rate.."/>
+    <string name="desc" value="Recovers the lost number of upgrades due to failed scroll by 1. Not available on Cash Items. Success rate:1%. If failed, the item will be destroyed at a 2% rate."/>
   </imgdir>
   <imgdir name="2049001">
     <string name="name" value="Clean Slate Scroll 3%"/>
-    <string name="desc" value="Recovers the lost number of upgrades due to failed scroll by 1. Success rate:3%, If failed, the item will be destroyed at a 6% rate.."/>
+    <string name="desc" value="Recovers the lost number of upgrades due to failed scroll by 1. Success rate:3%. If failed, the item will be destroyed at a 6% rate."/>
   </imgdir>
   <imgdir name="2049002">
     <string name="name" value="Clean Slate Scroll 5%"/>
-    <string name="desc" value="Recovers the lost number of upgrades due to failed scroll by 1. Success rate:5%, If failed, the item will be destroyed at a 10% rate.."/>
+    <string name="desc" value="Recovers the lost number of upgrades due to failed scroll by 1. Success rate:5%. If failed, the item will be destroyed at a 10% rate."/>
   </imgdir>
   <imgdir name="2049003">
     <string name="name" value="Clean Slate Scroll 20%"/>
-    <string name="desc" value="Recovers the lost number of upgrades due to failed scroll by 1. Success rate:20%, If failed, the item will be destroyed at a 50% rate.."/>
+    <string name="desc" value="Recovers the lost number of upgrades due to failed scroll by 1. Success rate:20%. If failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049100">
     <string name="name" value="Chaos Scroll 60%"/>
@@ -3629,7 +3629,7 @@
   </imgdir>
   <imgdir name="2049102">
     <string name="name" value="Maple Syrup 100%"/>
-    <string name="desc" value="Use it on Maple Leaf to improve or downgrade the item option. Success rate:100%"/>
+    <string name="desc" value="Use it on Maple Leaf to improve or downgrade the item option.\nSuccess rate:100%"/>
   </imgdir>
   <imgdir name="2049104">
     <string name="name" value="Agent Equipment Scroll 100%"/>
@@ -3641,7 +3641,7 @@
   </imgdir>
   <imgdir name="2050001">
     <string name="name" value="Eyedrop"/>
-    <string name="desc" value="Cures the state of darkness"/>
+    <string name="desc" value="Cures the state of darkness."/>
   </imgdir>
   <imgdir name="2050002">
     <string name="name" value="Tonic"/>
@@ -3677,19 +3677,19 @@
   </imgdir>
   <imgdir name="2060001">
     <string name="name" value="Bronze Arrow for Bow"/>
-    <string name="desc" value="A barrel full of bronze arrows. Only usable with bows.\nAttack + 1"/>
+    <string name="desc" value="A barrel full of bronze arrows. Only usable with bows.\nAttack+1"/>
   </imgdir>
   <imgdir name="2060002">
     <string name="name" value="Steel Arrow for Bow"/>
-    <string name="desc" value="A barrel full of steel arrows. Only usable with bows.\nSTR +1, Attack +1"/>
+    <string name="desc" value="A barrel full of steel arrows. Only usable with bows.\nSTR+1, Attack+1"/>
   </imgdir>
   <imgdir name="2060003">
     <string name="name" value="Red Arrow for Bow"/>
-    <string name="desc" value="A case full of arrows. Can only be used with a bow. \nAttack + 4."/>
+    <string name="desc" value="A case full of arrows. Can only be used with a bow.\nAttack+4."/>
   </imgdir>
   <imgdir name="2060004">
     <string name="name" value="Diamond Arrow for Bow"/>
-    <string name="desc" value="A case full of arrows. Can only be used with a bow.nAttack + 4."/>
+    <string name="desc" value="A case full of arrows. Can only be used with a bow.nAttack+4."/>
   </imgdir>
   <imgdir name="2060005">
     <string name="name" value="Snowball"/>
@@ -3697,7 +3697,7 @@
   </imgdir>
   <imgdir name="2060006">
     <string name="name" value="Big Snowball"/>
-    <string name="desc" value="A bigger, more intimidating packed ball of snow. Can be thrown to inflict damage."/>
+    <string name="desc" value="A bigger, more intimidating, packed ball of snow. Can be thrown to inflict damage."/>
   </imgdir>
   <imgdir name="2061000">
     <string name="name" value="Arrow for Crossbow"/>
@@ -3705,87 +3705,87 @@
   </imgdir>
   <imgdir name="2061001">
     <string name="name" value="Bronze Arrow for Crossbow"/>
-    <string name="desc" value="A barrel full of bronze arrows. Only usable with crossbows.\nAttack + 1"/>
+    <string name="desc" value="A barrel full of bronze arrows. Only usable with crossbows.\nAttack+1"/>
   </imgdir>
   <imgdir name="2061002">
     <string name="name" value="Steel Arrow for Crossbow"/>
-    <string name="desc" value="A barrel full of steel arrows. Only usable with crossbows.nAttack +2"/>
+    <string name="desc" value="A barrel full of steel arrows. Only usable with crossbows.\nAttack+2"/>
   </imgdir>
   <imgdir name="2061003">
     <string name="name" value="Blue Arrow for Crossbow"/>
-    <string name="desc" value="A case full of arrows. Can only be used with a crossbow.nAttack + 4."/>
+    <string name="desc" value="A case full of arrows. Can only be used with a crossbow.\nAttack+4."/>
   </imgdir>
   <imgdir name="2061004">
     <string name="name" value="Diamond Arrow for Crossbow"/>
-    <string name="desc" value="A case full of arrows. Can only be used with a crossbow.nAttack + 4."/>
+    <string name="desc" value="A case full of arrows. Can only be used with a crossbow.\nAttack+4."/>
   </imgdir>
   <imgdir name="2070000">
     <string name="name" value="Subi Throwing-Stars"/>
-    <string name="desc" value="A throwing-star made out of steel. Once they run out, they need to be recharged.\nLevel Limit : 10, Attack + 15"/>
+    <string name="desc" value="A throwing star made out of steel. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+15"/>
   </imgdir>
   <imgdir name="2070001">
     <string name="name" value="Wolbi Throwing-Stars"/>
-    <string name="desc" value="A throwing-star made out of steel. Once they run out, they need to be recharged.\nLevel Limit : 10, Attack + 17"/>
+    <string name="desc" value="A throwing star made out of steel. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+17"/>
   </imgdir>
   <imgdir name="2070002">
     <string name="name" value="Mokbi Throwing-Stars"/>
-    <string name="desc" value="A throwing-star made out of steel. Once they run out, they need to be recharged.\nLevel Limit : 10, Attack + 19"/>
+    <string name="desc" value="A throwing star made out of steel. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+19"/>
   </imgdir>
   <imgdir name="2070003">
     <string name="name" value="Kumbi Throwing-Stars"/>
-    <string name="desc" value="A throwing-star made out of steel. Once they run out, they need to be recharged.\nLevel Limit : 10, Attack + 21"/>
+    <string name="desc" value="A throwing star made out of steel. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+21"/>
   </imgdir>
   <imgdir name="2070004">
     <string name="name" value="Tobi Throwing-Stars"/>
-    <string name="desc" value="A throwing-star made out of steel. Once they run out, they need to be recharged.\nLevel Limit : 10, Attack + 23"/>
+    <string name="desc" value="A throwing star made out of steel. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+23"/>
   </imgdir>
   <imgdir name="2070005">
     <string name="name" value="Steely Throwing-Knives"/>
-    <string name="desc" value="A throwing-star made out of steel. Once they run out, they need to be recharged.\nLevel Limit : 10, Attack + 25"/>
+    <string name="desc" value="A throwing star made out of steel. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+25"/>
   </imgdir>
   <imgdir name="2070006">
     <string name="name" value="Ilbi Throwing-Stars"/>
-    <string name="desc" value="A throwing-star made out of steel. Once they run out, they need to be recharged.\nLevel Limit : 10, Attack + 27"/>
+    <string name="desc" value="A throwing star made out of steel. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+27"/>
   </imgdir>
   <imgdir name="2070007">
     <string name="name" value="Hwabi Throwing-Stars"/>
-    <string name="desc" value="A throwing-star made out of steel. Once they run out, they need to be recharged.\nLevel Limit : 10, Attack + 27"/>
+    <string name="desc" value="A throwing star made out of steel. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+27"/>
   </imgdir>
   <imgdir name="2070008">
     <string name="name" value="Snowball"/>
-    <string name="desc" value="A well-packed snowball. Once they run out, they need to be recharged.\nLevel Limit : 10, Attack + 17"/>
+    <string name="desc" value="A well-packed snowball. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+17"/>
   </imgdir>
   <imgdir name="2070009">
     <string name="name" value="Wooden Top"/>
-    <string name="desc" value="When thrown, it spins fast and flies at great speed. Once they are all used up, they need to be recharged.\nLevel Limit : 10, Attack + 19"/>
+    <string name="desc" value="When thrown, it spins fast and flies at great speed. Once they are all used up, they need to be recharged.\nLevel Limit:10, Attack+19"/>
   </imgdir>
   <imgdir name="2070010">
     <string name="name" value="Icicle"/>
-    <string name="desc" value="Sharp icicles. Once they run out, they need to be recharged.rnLevel Limit : 10, Attack + 21"/>
+    <string name="desc" value="Sharp icicles. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+21"/>
   </imgdir>
   <imgdir name="2070011">
     <string name="name" value="Maple Throwing-Stars"/>
-    <string name="desc" value="Maple-shaped steel throwing-stars. Once they run out, they need to be recharged.rnLevel Limit : 10, Attack + 21"/>
+    <string name="desc" value="Maple-shaped steel throwing stars. Once they run out, they need to be recharged.\nLevel Limit:10, Attack+21"/>
   </imgdir>
   <imgdir name="2070012">
     <string name="name" value="Paper Fighter Plane"/>
-    <string name="desc" value="A paper plane that can be thrown at things. Once they run out, they need to be recharged.\nAttack +20"/>
+    <string name="desc" value="A paper plane that can be thrown at things. Once they run out, they need to be recharged.\nAttack+20"/>
   </imgdir>
   <imgdir name="2070013">
     <string name="name" value="Orange"/>
-    <string name="desc" value="A tasty orange that can be thrown at things.\nAttack + 20"/>
+    <string name="desc" value="A tasty orange that can be thrown at things.\nAttack+20"/>
   </imgdir>
   <imgdir name="2070015">
     <string name="name" value="A Beginner Thief&apos;s Throwing Stars"/>
-    <string name="desc" value="These are steel throwing stars given by Dark Lord for Beginner Thieves. Unlike normal throwing stars, you can&apos;t recharge it. \nAttack + 15"/>
+    <string name="desc" value="These are steel throwing stars given by Dark Lord for Beginner Thieves. Unlike normal throwing stars, you can&apos;t recharge it.\nAttack+15"/>
   </imgdir>
   <imgdir name="2070016">
     <string name="name" value="Crystal Ilbi Throwing-Stars"/>
-    <string name="desc" value="A throwing-star made of crystal. Once they run out, they need to be recharged. rnAttack + 29"/>
+    <string name="desc" value="A throwing star made of crystal. Once they run out, they need to be recharged.\nAttack+29"/>
   </imgdir>
   <imgdir name="2070018">
     <string name="name" value="Balanced Fury"/>
-    <string name="desc" value="Ancient Shadowknight throwing stars made from black crystal.  These can be recharged when used up. rnAttack + 30"/>
+    <string name="desc" value="Ancient Shadowknight throwing stars made from black crystal. These can be recharged when used up.\nAttack+30"/>
   </imgdir>
   <imgdir name="2100000">
     <string name="name" value="Black Sack"/>
@@ -3793,55 +3793,55 @@
   </imgdir>
   <imgdir name="2100001">
     <string name="name" value="Monster Sack 1"/>
-    <string name="desc" value="Summons weak monsters of level 10 and under"/>
+    <string name="desc" value="Summons weak monsters of level 10 and under."/>
   </imgdir>
   <imgdir name="2100002">
     <string name="name" value="Monster Sack 2"/>
-    <string name="desc" value="Summons weak monsters between levels 10 and 20"/>
+    <string name="desc" value="Summons weak monsters between levels 10 and 20."/>
   </imgdir>
   <imgdir name="2100003">
     <string name="name" value="Monster Sack 3"/>
-    <string name="desc" value="Summons mid-lower-leveled monsters between levels 20 and 30"/>
+    <string name="desc" value="Summons mid-lower-leveled monsters between levels 20 and 30."/>
   </imgdir>
   <imgdir name="2100004">
     <string name="name" value="Monster Sack 4"/>
-    <string name="desc" value="Summons mid-level monsters between levels 30 and 40"/>
+    <string name="desc" value="Summons mid-level monsters between levels 30 and 40."/>
   </imgdir>
   <imgdir name="2100005">
     <string name="name" value="Monster Sack 5"/>
-    <string name="desc" value="Summons mid-leveled monsters between levels 40 and 50"/>
+    <string name="desc" value="Summons mid-leveled monsters between levels 40 and 50."/>
   </imgdir>
   <imgdir name="2100006">
     <string name="name" value="Monster Sack 6"/>
-    <string name="desc" value="Summons high-leveled monsters between levels 50 and 60"/>
+    <string name="desc" value="Summons high-leveled monsters between levels 50 and 60."/>
   </imgdir>
   <imgdir name="2100007">
     <string name="name" value="Monster Sack 7"/>
-    <string name="desc" value="Summons high-leveled monsters between levels 60 and 70"/>
+    <string name="desc" value="Summons high-leveled monsters between levels 60 and 70."/>
   </imgdir>
   <imgdir name="2100008">
     <string name="name" value="Summoning the Boss"/>
-    <string name="desc" value="To the old, the pregnant, and the low-leveled : don&apos;t even bother..."/>
+    <string name="desc" value="To the old, the pregnant, and the low-leveled: don&apos;t even bother..."/>
   </imgdir>
   <imgdir name="2100009">
     <string name="name" value="Summoning New-Type Balrog"/>
-    <string name="desc" value="The moment you summon it...you&apos;re dead already"/>
+    <string name="desc" value="The moment you summon it... you&apos;re dead already."/>
   </imgdir>
   <imgdir name="2100010">
     <string name="name" value="Summoning &quot;Dances with Balrog&apos;s Clone&quot;"/>
-    <string name="desc" value="Summons Dances with Balrog&apos;s Clone"/>
+    <string name="desc" value="Summons Dances with Balrog&apos;s Clone."/>
   </imgdir>
   <imgdir name="2100011">
     <string name="name" value="Summoning Grendel the Really Old&apos;s Clone"/>
-    <string name="desc" value="Summons Grendel the Really Old&apos;s Clone"/>
+    <string name="desc" value="Summons Grendel the Really Old&apos;s Clone."/>
   </imgdir>
   <imgdir name="2100012">
     <string name="name" value="Summoning Athena Pierce&apos;s Clone"/>
-    <string name="desc" value="Summons Athena Pierce&apos;s Clone"/>
+    <string name="desc" value="Summons Athena Pierce&apos;s Clone."/>
   </imgdir>
   <imgdir name="2100013">
     <string name="name" value="Summoning Dark Lord&apos;s Clone"/>
-    <string name="desc" value="Summons Dark Lord&apos;s Clone"/>
+    <string name="desc" value="Summons Dark Lord&apos;s Clone."/>
   </imgdir>
   <imgdir name="2100014">
     <string name="name" value="Brand New Monster Galore"/>
@@ -3849,7 +3849,7 @@
   </imgdir>
   <imgdir name="2100015">
     <string name="name" value="Summoning Bag of Birds"/>
-    <string name="desc" value="A bag, which summons blue and pink birds living in Eos Tower"/>
+    <string name="desc" value="A bag that summons blue and pink birds living in Eos Tower."/>
   </imgdir>
   <imgdir name="2100016">
     <string name="name" value="Different Sack"/>
@@ -3857,7 +3857,7 @@
   </imgdir>
   <imgdir name="2100017">
     <string name="name" value="Alien Sack"/>
-    <string name="desc" value="A sack full of aliens"/>
+    <string name="desc" value="A sack full of aliens."/>
   </imgdir>
   <imgdir name="2100018">
     <string name="name" value="Toy Robot Sack"/>
@@ -3901,7 +3901,7 @@
   </imgdir>
   <imgdir name="2100028">
     <string name="name" value="Summoning Three-Tail Fox"/>
-    <string name="desc" value="A peculiar summon sack that summons Three-Tail Fox"/>
+    <string name="desc" value="A peculiar summon sack that summons Three-Tail Fox."/>
   </imgdir>
   <imgdir name="2100029">
     <string name="name" value="Summoning Ghosts"/>
@@ -3921,35 +3921,35 @@
   </imgdir>
   <imgdir name="2100033">
     <string name="name" value="Monster Sack 8"/>
-    <string name="desc" value="Summons high-leveled monsters between levels 70 and 80"/>
+    <string name="desc" value="Summons high-leveled monsters between levels 70 and 80."/>
   </imgdir>
   <imgdir name="2100034">
     <string name="name" value="Monster Sack 9"/>
-    <string name="desc" value="Summons high-leveled monsters between levels 80 and 90"/>
+    <string name="desc" value="Summons high-leveled monsters between levels 80 and 90."/>
   </imgdir>
   <imgdir name="2100035">
     <string name="name" value="Monster Sack 10"/>
-    <string name="desc" value="Summons high-leveled monsters between levels 90 and 100"/>
+    <string name="desc" value="Summons high-leveled monsters between levels 90 and 100."/>
   </imgdir>
   <imgdir name="2100036">
     <string name="name" value="Monster Sack 11"/>
-    <string name="desc" value="Summons high-leveled monsters between levels 100 and 110"/>
+    <string name="desc" value="Summons high-leveled monsters between levels 100 and 110."/>
   </imgdir>
   <imgdir name="2100037">
     <string name="name" value="Summon Master Monsters 1"/>
-    <string name="desc" value="Summon the Event-only Mano &amp; Stumpy."/>
+    <string name="desc" value="Summon the event-only Mano &amp; Stumpy."/>
   </imgdir>
   <imgdir name="2100038">
     <string name="name" value="Summon Master Monsters 2"/>
-    <string name="desc" value="Summon the Event-only Faust, King Clang, Timer, and Dyle."/>
+    <string name="desc" value="Summon the event-only Faust, King Clang, Timer, and Dyle."/>
   </imgdir>
   <imgdir name="2100039">
     <string name="name" value="Summon Master Monsters 3"/>
-    <string name="desc" value="Summon the Event-only Nine-Tailed Fox, Tae Roon, and King Sage Cat."/>
+    <string name="desc" value="Summon the event-only Nine-Tailed Fox, Tae Roon, and King Sage Cat."/>
   </imgdir>
   <imgdir name="2100040">
     <string name="name" value="Summon Master Monsters 4"/>
-    <string name="desc" value="Summon the Event-only Elliza, and Snowman."/>
+    <string name="desc" value="Summon the event-only Elliza, and Snowman."/>
   </imgdir>
   <imgdir name="2100041">
     <string name="name" value="Summoning Lord Pirate"/>
@@ -3985,7 +3985,7 @@
   </imgdir>
   <imgdir name="2100049">
     <string name="name" value="Summoning Lord Pirate&apos;s Mr. Alli"/>
-    <string name="desc" value="Summons Lord Pirate&apos;s Mr. Alli"/>
+    <string name="desc" value="Summons Lord Pirate&apos;s Mr. Alli."/>
   </imgdir>
   <imgdir name="2100050">
     <string name="name" value="Summoning Lord Pirate&apos;s Kru"/>
@@ -4001,31 +4001,31 @@
   </imgdir>
   <imgdir name="2100053">
     <string name="name" value="Summon Romeo and Juliet PQ Mob"/>
-    <string name="desc" value="Summon Rabbit bundle"/>
+    <string name="desc" value="Summon Rabbit bundle."/>
   </imgdir>
   <imgdir name="2100054">
     <string name="name" value="Summon Romeo and Juliet PQ Mob"/>
-    <string name="desc" value="Summon Frankenroid"/>
+    <string name="desc" value="Summon Frankenroid."/>
   </imgdir>
   <imgdir name="2100055">
     <string name="name" value="Summon Romeo and Juliet PQ Mob"/>
-    <string name="desc" value="Summon Angry Frankenroid"/>
+    <string name="desc" value="Summon Angry Frankenroid."/>
   </imgdir>
   <imgdir name="2100056">
     <string name="name" value="Summon Romeo and Juliet PQ Mob"/>
-    <string name="desc" value="Summon Fallen Romeo"/>
+    <string name="desc" value="Summon Fallen Romeo."/>
   </imgdir>
   <imgdir name="2100057">
     <string name="name" value="Summon Romeo and Juliet PQ Mob"/>
-    <string name="desc" value="Summon Fallen Romeo"/>
+    <string name="desc" value="Summon Fallen Romeo."/>
   </imgdir>
   <imgdir name="2100058">
     <string name="name" value="Summon Romeo and Juliet PQ Mob"/>
-    <string name="desc" value="Summon Frankenroid"/>
+    <string name="desc" value="Summon Frankenroid."/>
   </imgdir>
   <imgdir name="2100059">
     <string name="name" value="Summon Romeo and Juliet PQ Mob"/>
-    <string name="desc" value="Summon Angry Frankenroid"/>
+    <string name="desc" value="Summon Angry Frankenroid."/>
   </imgdir>
   <imgdir name="2100060">
     <string name="name" value="Weird Sack"/>
@@ -4041,15 +4041,15 @@
   </imgdir>
   <imgdir name="2100063">
     <string name="name" value="Summon Ghost"/>
-    <string name="desc" value="Summon Mirror Ghost"/>
+    <string name="desc" value="Summon Mirror Ghost."/>
   </imgdir>
   <imgdir name="2100064">
     <string name="name" value="Summon Ghost  2"/>
-    <string name="desc" value="Summon Mirror Ghost"/>
+    <string name="desc" value="Summon Mirror Ghost."/>
   </imgdir>
   <imgdir name="2100065">
     <string name="name" value="Summon Ghost  3"/>
-    <string name="desc" value="Summon Mirror Ghost"/>
+    <string name="desc" value="Summon Mirror Ghost."/>
   </imgdir>
   <imgdir name="2100066">
     <string name="name" value="Summon Slime"/>
@@ -4065,7 +4065,7 @@
   </imgdir>
   <imgdir name="2100069">
     <string name="name" value="Event Box"/>
-    <string name="desc" value="For Events"/>
+    <string name="desc" value="For events."/>
   </imgdir>
   <imgdir name="2100070">
     <string name="name" value="1st Monster Marble"/>
@@ -4073,39 +4073,39 @@
   </imgdir>
   <imgdir name="2100071">
     <string name="name" value="Mu Lung Dojo Summon Package1_Mano"/>
-    <string name="desc" value="Summon Mano"/>
+    <string name="desc" value="Summon Mano."/>
   </imgdir>
   <imgdir name="2100072">
     <string name="name" value="Mu Lung Dojo Summon Package2_Stumpy"/>
-    <string name="desc" value="Summon Stumpy"/>
+    <string name="desc" value="Summon Stumpy."/>
   </imgdir>
   <imgdir name="2101000">
     <string name="name" value="Summoning Mushmom"/>
-    <string name="desc" value="Summons a Mushmom"/>
+    <string name="desc" value="Summons a Mushmom."/>
   </imgdir>
   <imgdir name="2101001">
     <string name="name" value="Summoning Crimson Balrog"/>
-    <string name="desc" value="Summons a Crimson Balrog"/>
+    <string name="desc" value="Summons a Crimson Balrog."/>
   </imgdir>
   <imgdir name="2101002">
     <string name="name" value="Summoning Werewolf"/>
-    <string name="desc" value="Summons a Werewolf"/>
+    <string name="desc" value="Summons a Werewolf."/>
   </imgdir>
   <imgdir name="2101003">
     <string name="name" value="Summoning Yeti &amp; Pepe"/>
-    <string name="desc" value="Summons one set of Yeti &amp; Pepe"/>
+    <string name="desc" value="Summons one set of Yeti &amp; Pepe."/>
   </imgdir>
   <imgdir name="2101004">
     <string name="name" value="Summoning Superslime"/>
-    <string name="desc" value="Summons a Superslime"/>
+    <string name="desc" value="Summons a Superslime."/>
   </imgdir>
   <imgdir name="2101005">
     <string name="name" value="Summoning Tauromacis"/>
-    <string name="desc" value="Summons a Tauromacis"/>
+    <string name="desc" value="Summons a Tauromacis."/>
   </imgdir>
   <imgdir name="2101006">
     <string name="name" value="Summoning Taurospear"/>
-    <string name="desc" value="Summons a Taurospear"/>
+    <string name="desc" value="Summons a Taurospear."/>
   </imgdir>
   <imgdir name="2101007">
     <string name="name" value="Summoning Lycanthrope"/>
@@ -4149,7 +4149,7 @@
   </imgdir>
   <imgdir name="2101021">
     <string name="name" value="Monster Sack (Jr. Mimick)"/>
-    <string name="desc" value="Summons 1 Jr. Mimick"/>
+    <string name="desc" value="Summons 1 Jr. Mimick."/>
   </imgdir>
   <imgdir name="2101023">
     <string name="name" value="Monster Sack (Slime Gold)"/>
@@ -4205,27 +4205,27 @@
   </imgdir>
   <imgdir name="2101051">
     <string name="name" value="GM event Sack2"/>
-    <string name="desc" value="Summons some monsters. Mushroom Boom"/>
+    <string name="desc" value="Summons some monsters. Mushroom Boom."/>
   </imgdir>
   <imgdir name="2101052">
     <string name="name" value="GM event Sack3"/>
-    <string name="desc" value="Summons some monsters. Pigs in a Blanket"/>
+    <string name="desc" value="Summons some monsters. Pigs in a Blanket."/>
   </imgdir>
   <imgdir name="2101053">
     <string name="name" value="GM event Sack4"/>
-    <string name="desc" value="Summons some monsters. Eye See You"/>
+    <string name="desc" value="Summons some monsters. Eye See You."/>
   </imgdir>
   <imgdir name="2101054">
     <string name="name" value="GM event Sack5"/>
-    <string name="desc" value="Summons some monsters. Alien Armada"/>
+    <string name="desc" value="Summons some monsters. Alien Armada."/>
   </imgdir>
   <imgdir name="2101055">
     <string name="name" value="GM event Sack6"/>
-    <string name="desc" value="Summons some monsters. Toying Around"/>
+    <string name="desc" value="Summons some monsters. Toying Around."/>
   </imgdir>
   <imgdir name="2101056">
     <string name="name" value="GM event Sack7"/>
-    <string name="desc" value="Summons some monsters. Crimson Crash"/>
+    <string name="desc" value="Summons some monsters. Crimson Crash."/>
   </imgdir>
   <imgdir name="2101057">
     <string name="name" value="Amoria Penalty Monster Sack8"/>
@@ -4233,11 +4233,11 @@
   </imgdir>
   <imgdir name="2101060">
     <string name="name" value="Monster Sack (SG CBD)"/>
-    <string name="desc" value="Summons 9 SG Exclusive monsters."/>
+    <string name="desc" value="Summons 9 SG-exclusive monsters."/>
   </imgdir>
   <imgdir name="2101061">
     <string name="name" value="Monster Sack (SG Ghost ship)"/>
-    <string name="desc" value="Summons 4 SG Exclusive monsters."/>
+    <string name="desc" value="Summons 4 SG-exclusive monsters."/>
   </imgdir>
   <imgdir name="2101072">
     <string name="name" value="Monster Sack"/>
@@ -4249,59 +4249,59 @@
   </imgdir>
   <imgdir name="2101080">
     <string name="name" value="Monster Sack(x-mas07_1)"/>
-    <string name="desc" value="Monster Sack(x-mas07_1)"/>
+    <string name="desc" value="Monster Sack(x-mas07_1)."/>
   </imgdir>
   <imgdir name="2101081">
     <string name="name" value="Monster Sack(x-mas07_2)"/>
-    <string name="desc" value="Monster Sack(x-mas07_2)"/>
+    <string name="desc" value="Monster Sack(x-mas07_2)."/>
   </imgdir>
   <imgdir name="2101082">
     <string name="name" value="Monster Sack(x-mas07_3)"/>
-    <string name="desc" value="Monster Sack(x-mas07_3)"/>
+    <string name="desc" value="Monster Sack(x-mas07_3)."/>
   </imgdir>
   <imgdir name="2101083">
     <string name="name" value="Monster Sack(x-mas07_4)"/>
-    <string name="desc" value="Monster Sack(x-mas07_4)"/>
+    <string name="desc" value="Monster Sack(x-mas07_4)."/>
   </imgdir>
   <imgdir name="2101084">
     <string name="name" value="Monster Sack(x-mas07_5)"/>
-    <string name="desc" value="Monster Sack(x-mas07_5)"/>
+    <string name="desc" value="Monster Sack(x-mas07_5)."/>
   </imgdir>
   <imgdir name="2101085">
     <string name="name" value="Monster Sack(x-mas07_6)"/>
-    <string name="desc" value="Monster Sack(x-mas07_6)"/>
+    <string name="desc" value="Monster Sack(x-mas07_6)."/>
   </imgdir>
   <imgdir name="2101086">
     <string name="name" value="Monster Sack(x-mas07_7)"/>
-    <string name="desc" value="Monster Sack(x-mas07_7)"/>
+    <string name="desc" value="Monster Sack(x-mas07_7)."/>
   </imgdir>
   <imgdir name="2101087">
     <string name="name" value="Monster Sack(x-mas07_8)"/>
-    <string name="desc" value="Monster Sack(x-mas07_8)"/>
+    <string name="desc" value="Monster Sack(x-mas07_8)."/>
   </imgdir>
   <imgdir name="2101088">
     <string name="name" value="Monster Sack(x-mas07_9)"/>
-    <string name="desc" value="Monster Sack(x-mas07_9)"/>
+    <string name="desc" value="Monster Sack(x-mas07_9)."/>
   </imgdir>
   <imgdir name="2101089">
     <string name="name" value="Monster Sack(x-mas07_10)"/>
-    <string name="desc" value="Monster Sack(x-mas07_10)"/>
+    <string name="desc" value="Monster Sack(x-mas07_10)."/>
   </imgdir>
   <imgdir name="2101090">
     <string name="name" value="Monster Sack(x-mas07_11)"/>
-    <string name="desc" value="Monster Sack(x-mas07_11)"/>
+    <string name="desc" value="Monster Sack(x-mas07_11)."/>
   </imgdir>
   <imgdir name="2101091">
     <string name="name" value="Monster Sack(x-mas07_12)"/>
-    <string name="desc" value="Monster Sack(x-mas07_12)"/>
+    <string name="desc" value="Monster Sack(x-mas07_12)."/>
   </imgdir>
   <imgdir name="2101092">
     <string name="name" value="Monster Sack(x-mas07_13)"/>
-    <string name="desc" value="Monster Sack(x-mas07_13)"/>
+    <string name="desc" value="Monster Sack(x-mas07_13)."/>
   </imgdir>
   <imgdir name="2101093">
     <string name="name" value="Monster Sack(x-mas07_14)"/>
-    <string name="desc" value="Monster Sack(x-mas07_14)"/>
+    <string name="desc" value="Monster Sack(x-mas07_14)."/>
   </imgdir>
   <imgdir name="2101124">
     <string name="name" value="Giant Snowman (Lvl 1) - Easy Sack"/>
@@ -4345,7 +4345,7 @@
   </imgdir>
   <imgdir name="2101139">
     <string name="name" value="Masteria Summoning Bag-Bosses"/>
-    <string name="desc" value="A mysterious black sack that calls forth powerful monsters from Masteria. Not for the faint of heart!  Bigfoot will stomp nearly anyone!"/>
+    <string name="desc" value="A mysterious black sack that calls forth powerful monsters from Masteria. Not for the faint of heart! Bigfoot will stomp nearly anyone!"/>
   </imgdir>
   <imgdir name="2101140">
     <string name="name" value="MasteriaPQ Summon Bag1"/>
@@ -4376,7 +4376,7 @@
   </imgdir>
   <imgdir name="2101158">
     <string name="name" value="Big Puff Daddy Sack"/>
-    <string name="desc" value="A sack filled with Big Puff Daddys"/>
+    <string name="desc" value="A sack filled with Big Puff Daddys."/>
   </imgdir>
   <imgdir name="2102000">
     <string name="name" value="Monster Attack Lvl 1"/>
@@ -4384,19 +4384,19 @@
   </imgdir>
   <imgdir name="2102001">
     <string name="name" value="Monster Attack Lvl 2"/>
-    <string name="desc" value="Summons 3 Drumming Bunnies, Ligators, Ratz, Star Pixie&apos;s, Jr. Wraith&apos;s, and Jr. Pepe&apos;s each."/>
+    <string name="desc" value="Summons 3 Drumming Bunnies, Ligators, Ratz, Star Pixies, Jr. Wraiths, and Jr. Pepes each."/>
   </imgdir>
   <imgdir name="2102002">
     <string name="name" value="Monster Attack Lvl 3"/>
-    <string name="desc" value="Summons 3 Panda Teddy&apos;s, King Bloctopuses, Lorangs, Zombie Lupins, Hellies, and Tweeters each."/>
+    <string name="desc" value="Summons 3 Panda Teddies, King Bloctopuses, Lorangs, Zombie Lupins, Hellies, and Tweeters each."/>
   </imgdir>
   <imgdir name="2102003">
     <string name="name" value="Monster Attack Lvl 4"/>
-    <string name="desc" value="Summons 3 Toy Trojans, King Block Golems, Wraiths, Cheif Grey&apos;s, and Mixed Golems each."/>
+    <string name="desc" value="Summons 3 Toy Trojans, King Block Golems, Wraiths, Cheif Grays, and Mixed Golems each."/>
   </imgdir>
   <imgdir name="2102004">
     <string name="name" value="Monster Attack Lvl 5"/>
-    <string name="desc" value="Summons 3 Mushmoms, Red Drakes, Ice Drakes, Master Soul Teddy&apos;s, and Dark Yeti&apos;s each."/>
+    <string name="desc" value="Summons 3 Mushmoms, Red Drakes, Ice Drakes, Master Soul Teddies, and Dark Yetis each."/>
   </imgdir>
   <imgdir name="2102005">
     <string name="name" value="Monster Attack Lvl 6"/>
@@ -4404,7 +4404,7 @@
   </imgdir>
   <imgdir name="2102006">
     <string name="name" value="Monster Attack Lvl 7"/>
-    <string name="desc" value="Summons 3 Lycanthropes, Death Teddy&apos;s, Gigantic Spirit Vikings, and G. Phantom Watches each."/>
+    <string name="desc" value="Summons 3 Lycanthropes, Death Teddies, Gigantic Spirit Vikings, and G. Phantom Watches each."/>
   </imgdir>
   <imgdir name="2102007">
     <string name="name" value="Monster Attack Lvl 8"/>
@@ -4436,7 +4436,7 @@
   </imgdir>
   <imgdir name="2120000">
     <string name="name" value="Pet Food"/>
-    <string name="desc" value="Small pets love them. Recovers 30 Fullness. NOT for human!"/>
+    <string name="desc" value="Small pets love them. Recovers 30 Fullness. NOT for humans!"/>
   </imgdir>
   <imgdir name="2120008">
     <string name="name" value="Dry Treat"/>
@@ -4464,7 +4464,7 @@
   </imgdir>
   <imgdir name="2210003">
     <string name="name" value="Dragon Elixir"/>
-    <string name="desc" value="A mysterious elixir made by Moira which enables anyone that drinks this potion to temporarily transform into a dragon."/>
+    <string name="desc" value="A mysterious elixir made by Moira that enables anyone who drinks this potion to temporarily transform into a dragon."/>
   </imgdir>
   <imgdir name="2210005">
     <string name="name" value="Tigun Transformation Bundle."/>
@@ -4504,15 +4504,15 @@
   </imgdir>
   <imgdir name="2210032">
     <string name="name" value="Cody&apos;s Picture"/>
-    <string name="desc" value="A picture given by Cody of himself.  I get a feeling something fun will happen when I use it."/>
+    <string name="desc" value="A picture given by Cody of himself. I get a feeling something fun will happen when I use it."/>
   </imgdir>
   <imgdir name="2210033">
     <string name="name" value="Cake Picture"/>
-    <string name="desc" value="A picture of a delicious cake that Cody gave as a gift.  I get a feeling something funny with happen when I use it."/>
+    <string name="desc" value="A picture of a delicious cake that Cody gave as a gift. I get a feeling something funny will happen when I use it."/>
   </imgdir>
   <imgdir name="2211000">
     <string name="name" value="Cliff&apos;s Special Potion"/>
-    <string name="desc" value="No one knows what you&apos;ll transform into when you drink this, but something WILL happen for one hour.  It&apos;s all about the risk..."/>
+    <string name="desc" value="No one knows what you&apos;ll transform into when you drink this, but something WILL happen for one hour. It&apos;s all about the risk..."/>
   </imgdir>
   <imgdir name="2212000">
     <string name="name" value="Maplemas Party Potion"/>
@@ -4572,7 +4572,7 @@
   </imgdir>
   <imgdir name="2280000">
     <string name="name" value="Lava Bottle"/>
-    <string name="desc" value="A glass bottle that contains an actual lava, which is waiting to be spilled out. Drink this lava, and the lava will consume the body with fire, which will enable the drinker to master Fire Demon."/>
+    <string name="desc" value="A glass bottle that contains actual lava, which is waiting to be spilled out. Drink this lava and the lava will consume the body with fire, which will enable the drinker to master Fire Demon."/>
   </imgdir>
   <imgdir name="2280001">
     <string name="name" value="Black Cloud Machine"/>
@@ -4584,43 +4584,43 @@
   </imgdir>
   <imgdir name="2280003">
     <string name="name" value="[Skill Book] Maple Warrior"/>
-    <string name="desc" value="You can learn #cMaple Warrior# with this book.rnJob : All 4th jobsrnCondition : #cMaple Warrior# not acquired."/>
+    <string name="desc" value="You can learn #cMaple Warrior# with this book.\nJob: All 4th jobs.\nCondition: #cMaple Warrior# not acquired."/>
   </imgdir>
   <imgdir name="2280004">
     <string name="name" value="[Skill Book] Infinity"/>
-    <string name="desc" value="You can learn #cInfinity# with this book.rnJob : 4th Advancement MagicianrnCondition : #cInfinity# not acquired"/>
+    <string name="desc" value="You can learn #cInfinity# with this book.\nJob: 4th Advancement Magician.\nCondition: #cInfinity# not acquired."/>
   </imgdir>
   <imgdir name="2280005">
     <string name="name" value="[Skill Book] Dragon&apos;s Breath"/>
-    <string name="desc" value="You can learn #cDragon&apos;s Breath# with this book.wnJob : 4th Advancement BowmanrnCondition : #cDragon&apos;s Breath# not acquired"/>
+    <string name="desc" value="You can learn #cDragon&apos;s Breath# with this book.\nJob: 4th Advancement Bowman.\nCondition: #cDragon&apos;s Breath# not acquired."/>
   </imgdir>
   <imgdir name="2280006">
     <string name="name" value="[Skill Book] Taunt"/>
-    <string name="desc" value="You can learn #cTaunt# with this book.rnJob : 4th Advancement ThiefrnCondition : #cTaunt# not acquired"/>
+    <string name="desc" value="You can learn #cTaunt# with this book.\nJob: 4th Advancement Thief.\nCondition: #cTaunt# not acquired."/>
   </imgdir>
   <imgdir name="2280007">
     <string name="name" value="[Skill Book] Advanced Combo Attack"/>
-    <string name="desc" value="You can learn #cAdvanced Combo Attack# with this book.rnClass : HerornCondition : #cAdvanced Combo# not acquired"/>
+    <string name="desc" value="You can learn #cAdvanced Combo Attack# with this book.\nClass: Hero.\nCondition: #cAdvanced Combo# not acquired."/>
   </imgdir>
   <imgdir name="2280008">
     <string name="name" value="[Skill Book] Advanced Charge"/>
-    <string name="desc" value="You can learn #cAdvanced Charge# with this book.rnClass : PaladinrnCondition : #cAdvanced Charge# not acquired"/>
+    <string name="desc" value="You can learn #cAdvanced Charge# with this book.\nClass: Paladin.\nCondition: #cAdvanced Charge# not acquired."/>
   </imgdir>
   <imgdir name="2280009">
     <string name="name" value="[Skill Book] Angel Ray"/>
-    <string name="desc" value="You can learn #cAngel Ray# with this book.rnClass : BishoprnCondition : #cAngel Ray# not acquired"/>
+    <string name="desc" value="You can learn #cAngel Ray# with this book.\nClass: Bishop.\nCondition: #cAngel Ray# not acquired."/>
   </imgdir>
   <imgdir name="2280010">
     <string name="name" value="[Skill Book] Triple Throw"/>
-    <string name="desc" value="You can learn #cTriple Throw# with this book.rnClass : Night LordrnCondition : #cTriple Throw# not acquired"/>
+    <string name="desc" value="You can learn #cTriple Throw# with this book.\nClass: Night Lord.\nCondition: #cTriple Throw# not acquired."/>
   </imgdir>
   <imgdir name="2280011">
     <string name="name" value="Ancient Ice Powder"/>
-    <string name="desc" value="This is a pack full of ancient ice powder. If you eat this,  you will feel chilled and can learn Ice Demon."/>
+    <string name="desc" value="This is a pack full of ancient ice powder. If you eat this, you will feel chilled and can learn Ice Demon."/>
   </imgdir>
   <imgdir name="2280012">
     <string name="name" value="[Skill Book] Rush"/>
-    <string name="desc" value="You can learn #cRush# with this book.rnJob : 4th Advancement WarriorrnCondition : #cRush# not acquired"/>
+    <string name="desc" value="You can learn #cRush# with this book.\nJob: 4th Advancement Warrior.\nCondition : #cRush# not acquired."/>
   </imgdir>
   <imgdir name="2310000">
     <string name="name" value="The Owl of Minerva"/>
@@ -4632,31 +4632,31 @@
   </imgdir>
   <imgdir name="2330000">
     <string name="name" value="Bullet"/>
-    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.\nAttack + 10"/>
+    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.\nAttack+10"/>
   </imgdir>
   <imgdir name="2330001">
     <string name="name" value="Split Bullet"/>
-    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.rnAttack + 12"/>
+    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.\nAttack+12"/>
   </imgdir>
   <imgdir name="2330002">
     <string name="name" value="Mighty Bullet"/>
-    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.rnAttack + 14"/>
+    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.\nAttack+14"/>
   </imgdir>
   <imgdir name="2330003">
     <string name="name" value="Vital Bullet"/>
-    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.rnAttack + 16"/>
+    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.\nAttack+16"/>
   </imgdir>
   <imgdir name="2330004">
     <string name="name" value="Shiny Bullet"/>
-    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.rnAttack + 18"/>
+    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.\nAttack+18"/>
   </imgdir>
   <imgdir name="2330005">
     <string name="name" value="Eternal Bullet"/>
-    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.\nAttack + 20"/>
+    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets and once they are used up, they&apos;ll need to be recharged.\nAttack+20"/>
   </imgdir>
   <imgdir name="2330006">
     <string name="name" value="Bullet for Novice Pirates"/>
-    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets.rnAttack + 10"/>
+    <string name="desc" value="A bullet made out of steel. A set contains numerous bullets.\nAttack+10"/>
   </imgdir>
   <imgdir name="2331000">
     <string name="name" value="Blaze Capsule"/>
@@ -4668,7 +4668,7 @@
   </imgdir>
   <imgdir name="2340000">
     <string name="name" value="White Scroll"/>
-    <string name="desc" value="One of Subani&apos;s sacred Scrolls. If used in conjunction with a normal or Dark Scroll, the number of item upgrade slots will not be deducted if the scroll fails. However, if using a Dark Scroll, there is still a chance that your weapon will be destroyed."/>
+    <string name="desc" value="One of Subani&apos;s sacred scrolls. If used in conjunction with a normal or Dark Scroll, the number of item upgrade slots will not be deducted if the scroll fails. However, if using a Dark Scroll, there is still a chance that your weapon will be destroyed."/>
   </imgdir>
   <imgdir name="2360000">
     <string name="name" value="Change to Ghost"/>
@@ -4680,67 +4680,67 @@
   </imgdir>
   <imgdir name="2370000">
     <string name="name" value="The Songs of Solomon"/>
-    <string name="desc" value="An ancient collection of poems and life lessons from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second.  This edition provides 100,000 EXP. Only available fo"/>
+    <string name="desc" value="An ancient collection of poems and life lessons from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 100,000 EXP. Only available for users under Level 51."/>
     <null name="r users under Level 51."/>
   </imgdir>
   <imgdir name="2370001">
     <string name="name" value="The Stories of Solomon"/>
-    <string name="desc" value="An ancient book of stories, fables and other myths from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second.  This edition provides 50,000 EXP. Only available"/>
+    <string name="desc" value="An ancient book of stories, fables and other myths from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 50,000 EXP. Only available for users under Level 51."/>
     <null name="for users under Level 51."/>
   </imgdir>
   <imgdir name="2370002">
     <string name="name" value="The Travels of Solomon"/>
-    <string name="desc" value="An ancient collection of map routes, hidden paths and shortcuts from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second.  This edition provides 30,000 EXP. On"/>
+    <string name="desc" value="An ancient collection of map routes, hidden paths and shortcuts from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 30,000 EXP. Only available for users under Level 51."/>
     <null name="ly available for users under Level 51."/>
   </imgdir>
   <imgdir name="2370003">
     <string name="name" value="The Writs of Solomon X"/>
-    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second.  This edition provides 20,000 EXP. Only available for users u"/>
+    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 20,000 EXP. Only available for users under Level 51."/>
     <null name="nder Level 51."/>
   </imgdir>
   <imgdir name="2370004">
     <string name="name" value="The Writs of Solomon IX"/>
-    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second.  This edition provides 10,000 EXP. Only available for users u"/>
+    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 10,000 EXP. Only available for users under Level 51."/>
     <null name="nder Level 51."/>
   </imgdir>
   <imgdir name="2370005">
     <string name="name" value="The Writs of Solomon VIII"/>
-    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second.  This edition provides 5,000 EXP. Only available for users un"/>
+    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 5,000 EXP. Only available for users under Level 51."/>
     <null name="der Level 51."/>
   </imgdir>
   <imgdir name="2370006">
     <string name="name" value="The Writs of Solomon VII"/>
-    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second.  This edition provides 3,000 EXP. Only available for users un"/>
+    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 3,000 EXP. Only available for users under Level 51."/>
     <null name="der Level 51."/>
   </imgdir>
   <imgdir name="2370007">
     <string name="name" value="The Writs of Solomon VI"/>
-    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second.  This edition provides 2,000 EXP. Only available for users un"/>
+    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 2,000 EXP. Only available for users under Level 51."/>
     <null name="der Level 51."/>
   </imgdir>
   <imgdir name="2370008">
     <string name="name" value="The Writs of Solomon V"/>
-    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second.  This edition provides 1,000 EXP. Only available for users un"/>
+    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 1,000 EXP. Only available for users under Level 51."/>
     <null name="der Level 51."/>
   </imgdir>
   <imgdir name="2370009">
     <string name="name" value="The Writs of Solomon IV"/>
-    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 500 EXP. Only available for users under"/>
+    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 500 EXP. Only available for users under Level 51."/>
     <null name="Level 51."/>
   </imgdir>
   <imgdir name="2370010">
     <string name="name" value="The Writs of Solomon III"/>
-    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 300 EXP. Only available for users under"/>
+    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 300 EXP. Only available for users under Level 51."/>
     <null name="Level 51."/>
   </imgdir>
   <imgdir name="2370011">
     <string name="name" value="The Writs of Solomon II"/>
-    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 200 EXP. Only available for users under"/>
+    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 200 EXP. Only available for users under Level 51."/>
     <null name="Level 51."/>
   </imgdir>
   <imgdir name="2370012">
     <string name="name" value="The Writs of Solomon I"/>
-    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 100 EXP. Only available for users under"/>
+    <string name="desc" value="An ancient document of collected wisdom from various elders, sages and warriors in the Maple World. Reading this allows one to gain their collective experience (EXP) in a single second. This edition provides 100 EXP. Only available for users under Level 51."/>
     <null name="Level 51."/>
   </imgdir>
   <imgdir name="2380000">
@@ -4953,1027 +4953,1027 @@
   </imgdir>
   <imgdir name="2382000">
     <string name="name" value="Chirppy Card"/>
-    <string name="desc" value="A card that features Chirppy.n#cIf hunting at Eos TowernSpeed +1#"/>
+    <string name="desc" value="A card that features Chirppy.\n#cIf hunting at Eos Tower, Speed+1#"/>
   </imgdir>
   <imgdir name="2382001">
     <string name="name" value="Drum Bunny Card"/>
-    <string name="desc" value="A card that features Drum Bunny.n#cImproves the drop rate of the Drum Bunny.#"/>
+    <string name="desc" value="A card that features Drum Bunny.\n#cImproves the drop rate of the Drum Bunny.#"/>
   </imgdir>
   <imgdir name="2382002">
     <string name="name" value="Ligator Card"/>
-    <string name="desc" value="A card that features Ligator.n#cIf hunting at the SwampnAvoidability +1#"/>
+    <string name="desc" value="A card that features Ligator.\n#cIf hunting at the Swamp, Avoidability+1#"/>
   </imgdir>
   <imgdir name="2382003">
     <string name="name" value="Fireboar Card"/>
-    <string name="desc" value="A card that features Fireboar.n#cIf hunting at PerionnDefense against fire-based attacks +3%#"/>
+    <string name="desc" value="A card that features Fireboar.\n#cIf hunting at Perion, Defense against fire-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382004">
     <string name="name" value="Pink Teddy Card"/>
-    <string name="desc" value="A card that features Pink Teddy.n#cIf hunting at the upper floors of the ClocktowernJump +1#"/>
+    <string name="desc" value="A card that features Pink Teddy.\n#cIf hunting at the upper floors of the Clocktower, Jump+1#"/>
   </imgdir>
   <imgdir name="2382005">
     <string name="name" value="Ratz Card"/>
-    <string name="desc" value="A card that features Ratz.n#cIf hunting at Eos TowernMeso drop rate is increased#"/>
+    <string name="desc" value="A card that features Ratz.\n#cIf hunting at Eos Tower, Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2382006">
     <string name="name" value="Leatty Card"/>
-    <string name="desc" value="A card that features Leatty.n#cIf hunting at Orbis TowernAccuracy +1#"/>
+    <string name="desc" value="A card that features Leatty.\n#cIf hunting at Orbis Tower, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382007">
     <string name="name" value="Mask Fish Card"/>
-    <string name="desc" value="A card that features Mask Fishn#cIf hunting at Aqua Roadnavoidability+1#"/>
+    <string name="desc" value="A card that features Mask Fish.\n#cIf hunting at Aqua Road, Avoidability+1#"/>
   </imgdir>
   <imgdir name="2382008">
     <string name="name" value="Sand Dwarf Card"/>
-    <string name="desc" value="A card that features Sand Dwarf.n#cIf hunting at the DesertnThe drop rate for ores are increased#"/>
+    <string name="desc" value="A card that features Sand Dwarf.\n#cIf hunting at the Desert, The drop rate for ores are increased#"/>
   </imgdir>
   <imgdir name="2382009">
     <string name="name" value="Cube Slime Card"/>
-    <string name="desc" value="A card that features Cube Slime.n#cIf hunting at the Zenumist InstitutenJump +1#"/>
+    <string name="desc" value="A card that features Cube Slime.\n#cIf hunting at the Zenumist Institute, Jump+1#"/>
   </imgdir>
   <imgdir name="2382010">
     <string name="name" value="Red Sand Dwarf Card"/>
-    <string name="desc" value="A card that features Red Sand Dwarf.n#cIf hunting at the DesertnThe drop rate for jewels are increased#"/>
+    <string name="desc" value="A card that features Red Sand Dwarf.\n#cIf hunting at the Desert, The drop rate for jewels are increased#"/>
   </imgdir>
   <imgdir name="2382011">
     <string name="name" value="Jr. Cellion Card"/>
-    <string name="desc" value="A card that features Jr. Cellion.n#cIf hunting at the Orbis GardennDefense against fire-based attacks +3%#"/>
+    <string name="desc" value="A card that features Jr. Cellion.\n#cIf hunting at the Orbis Garden, Defense against fire-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382012">
     <string name="name" value="Jr. Lioner Card"/>
-    <string name="desc" value="A card that features Jr. Lioner.n#cIf hunting at the Orbis GardennDefense against electric-based attacks +3%#"/>
+    <string name="desc" value="A card that features Jr. Lioner.\n#cIf hunting at the Orbis Garden, Defense against electric-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382013">
     <string name="name" value="Jr. Grupin Card"/>
-    <string name="desc" value="A card that features Jr. Grupin.n#cIf hunting at the Orbis GardennDefense against ice-based attacks +3%#"/>
+    <string name="desc" value="A card that features Jr. Grupin.\n#cIf hunting at the Orbis Garden, Defense against ice-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382014">
     <string name="name" value="Dark Leatty Card"/>
-    <string name="desc" value="A card that features Dark Leatty.n#cIf hunting at Orbis TowernAccuracy +1#"/>
+    <string name="desc" value="A card that features Dark Leatty.\n#cIf hunting at Orbis Tower, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382015">
     <string name="name" value="Roloduck Card"/>
-    <string name="desc" value="A card that features Roloduck.n#cWhen party huntingnAccuracy +1#"/>
+    <string name="desc" value="A card that features Roloduck.\n#cWhen party hunting, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382016">
     <string name="name" value="Black Ratz Card"/>
-    <string name="desc" value="A card that features Black Ratz.n#cIf hunting at Eos TowernMeso drop rate is increased#"/>
+    <string name="desc" value="A card that features Black Ratz.\n#cIf hunting at Eos Tower, Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2382017">
     <string name="name" value="Tick Card"/>
-    <string name="desc" value="A card that features Tickn#cIf hunting at the upper floors of the ClocktowernAccuracy +1#"/>
+    <string name="desc" value="A card that features Tick.\n#cIf hunting at the upper floors of the Clocktower, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382018">
     <string name="name" value="Curse Eye Card"/>
-    <string name="desc" value="A card that features Curse Eye.n#cIf hunting at Victoria IslandnDefense against poison-based attacks +3%#"/>
+    <string name="desc" value="A card that features Curse Eye.\n#cIf hunting at Victoria Island, Defense against poison-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382019">
     <string name="name" value="Jr. Wraith Card"/>
-    <string name="desc" value="A card that features Jr. Wraith.n#cIf hunting at the SubwaynSpeed +1#"/>
+    <string name="desc" value="A card that features Jr. Wraith.\n#cIf hunting at the Subway, Speed+1#"/>
   </imgdir>
   <imgdir name="2382020">
     <string name="name" value="Star Pixie Card"/>
-    <string name="desc" value="A card that features Star Pixie.n#cIf hunting at the Cloud ParknSpeed +1#"/>
+    <string name="desc" value="A card that features Star Pixie.\n#cIf hunting at the Cloud Park, Speed+1#"/>
   </imgdir>
   <imgdir name="2382021">
     <string name="name" value="Jr. Boogie Card"/>
-    <string name="desc" value="A card that features Jr. Boogie.n#cDefense against curse +5%#"/>
+    <string name="desc" value="A card that features Jr. Boogie.\n#cDefense against curse+5%#"/>
   </imgdir>
   <imgdir name="2382022">
     <string name="name" value="Bloctopus Card"/>
-    <string name="desc" value="A card that features Bloctopus.n#cIf hunting at Eos TowernJump +1#"/>
+    <string name="desc" value="A card that features Bloctopus.\n#cIf hunting at Eos Tower, Jump+1#"/>
   </imgdir>
   <imgdir name="2382023">
     <string name="name" value="Jr. Pepe Card"/>
-    <string name="desc" value="A card that features Jr. Pepe.n#cIf hunting at Orbis TowernSpeed + 1#"/>
+    <string name="desc" value="A card that features Jr. Pepe.\n#cIf hunting at Orbis Tower, Speed+1#"/>
   </imgdir>
   <imgdir name="2382024">
     <string name="name" value="Rumo Card"/>
-    <string name="desc" value="A card that features Rumo.n#cIf hunting at the Zenumist InstitutenDefense against poison-based attacks +3%#"/>
+    <string name="desc" value="A card that features Rumo.\n#cIf hunting at the Zenumist Institute, Defense against poison-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382025">
     <string name="name" value="Panda Teddy Card"/>
-    <string name="desc" value="A card that features Panda Teddy.n#cIf attacking a weapon-carrying monsternAccuracy +1#"/>
+    <string name="desc" value="A card that features Panda Teddy.\n#cIf attacking a weapon-carrying monster, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382026">
     <string name="name" value="Helly Card"/>
-    <string name="desc" value="A card that features Helly.n#cIf hunting at Eos TowernAvoidability +1#"/>
+    <string name="desc" value="A card that features Helly.\n#cIf hunting at Eos Tower, Avoidability+1#"/>
   </imgdir>
   <imgdir name="2382027">
     <string name="name" value="Scuba Pepe Card"/>
-    <string name="desc" value="A card that features Scuba Pepe.n#cCancels out drowning damage underwater#"/>
+    <string name="desc" value="A card that features Scuba Pepe.\n#cCancels out drowning damage underwater#"/>
   </imgdir>
   <imgdir name="2382028">
     <string name="name" value="Retz"/>
-    <string name="desc" value="A card that features Retz.n#cIf hunting at Helios TowernItem drop rates are increased#"/>
+    <string name="desc" value="A card that features Retz.\n#cIf hunting at Helios Tower, Item drop rates are increased#"/>
   </imgdir>
   <imgdir name="2382029">
     <string name="name" value="Lupin Card"/>
-    <string name="desc" value="A card that features Lupin.n#cIf hunting at Victoria IslandnSpeed +1#"/>
+    <string name="desc" value="A card that features Lupin.\n#cIf hunting at Victoria Island, Speed+1#"/>
   </imgdir>
   <imgdir name="2382030">
     <string name="name" value="Lorang Card"/>
-    <string name="desc" value="A card that features Lorang.n#cIf hunting at Victoria IslandnSpeed +1#"/>
+    <string name="desc" value="A card that features Lorang.\n#cIf hunting at Victoria Island, Speed+1#"/>
   </imgdir>
   <imgdir name="2382031">
     <string name="name" value="Propelly Card"/>
-    <string name="desc" value="A card that features Propelly.n#cIf hunting at Eos TowernSpeed +1#"/>
+    <string name="desc" value="A card that features Propelly.\n#cIf hunting at Eos Tower, Speed+1#"/>
   </imgdir>
   <imgdir name="2382032">
     <string name="name" value="Chronos Card"/>
-    <string name="desc" value="A card that features Chronos.n#cIf hunting at the upper floors of the ClocktowernAvoidability +1#"/>
+    <string name="desc" value="A card that features Chronos.\n#cIf hunting at the upper floors of the Clocktower, Avoidability+1#"/>
   </imgdir>
   <imgdir name="2382033">
     <string name="name" value="King Bloctopus Card"/>
-    <string name="desc" value="A card that features King Bloctopus.n#cIf hunting at Eos TowernJump +1#"/>
+    <string name="desc" value="A card that features King Bloctopus.\n#cIf hunting at Eos Tower, Jump+1#"/>
   </imgdir>
   <imgdir name="2382034">
     <string name="name" value="Planey Card"/>
-    <string name="desc" value="A card that features Planey.n#cIf hunting at Eos TowernAccuracy +1#"/>
+    <string name="desc" value="A card that features Planey.\n#cIf hunting at Eos Tower, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382035">
     <string name="name" value="Jr. Seal Card"/>
-    <string name="desc" value="A card that features Jr. Seal.n#cIf hunting at Aqua RoadnJump +1#"/>
+    <string name="desc" value="A card that features Jr. Seal.\n#cIf hunting at Aqua Road, Jump+1#"/>
   </imgdir>
   <imgdir name="2382036">
     <string name="name" value="Triple Rumo Card"/>
-    <string name="desc" value="A card that features Triple Rumo.n#cIf hunting at the Zenumist InstitutenDefense against poison-based attacks +3%#"/>
+    <string name="desc" value="A card that features Triple Rumo.\n#cIf hunting at the Zenumist Institute, Defense against poison-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382037">
     <string name="name" value="Tweeter Card"/>
-    <string name="desc" value="A card that features Tweeter.n#cIf hunting at Eos TowernAccuracy +1#"/>
+    <string name="desc" value="A card that features Tweeter.\n#cIf hunting at Eos Tower, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382038">
     <string name="name" value="Toy Trojan Card"/>
-    <string name="desc" value="A card that features Toy Trojan.n#cIf hunting at the upper floors of the ClocktowernSpeed +1#"/>
+    <string name="desc" value="A card that features Toy Trojan.\n#cIf hunting at the upper floors of the Clocktower, Speed+1#"/>
   </imgdir>
   <imgdir name="2382039">
     <string name="name" value="Cold Eye Card"/>
-    <string name="desc" value="A card that features Cold Eye.n#cIf hunting at Victoria IslandnDefense against ice-based attacks +3%#"/>
+    <string name="desc" value="A card that features Cold Eye.\n#cIf hunting at Victoria Island, Defense against ice-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382040">
     <string name="name" value="Zombie Lupin Card"/>
-    <string name="desc" value="A card that features Zombie Lupin.n#cIncreases the drop rate of Cursed Doll#"/>
+    <string name="desc" value="A card that features Zombie Lupin.\n#cIncreases the drop rate of Cursed Doll#"/>
   </imgdir>
   <imgdir name="2382041">
     <string name="name" value="Tick-Tock Card"/>
-    <string name="desc" value="A card that features Tick-Tock.n#cIf hunting at the upper floors of the ClocktowernAccuracy +1#"/>
+    <string name="desc" value="A card that features Tick-Tock.\n#cIf hunting at the upper floors of the Clocktower, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382042">
     <string name="name" value="Barnard Grey Card"/>
-    <string name="desc" value="A card that features Barnard Grey.n#cIf hunting at Kulan FieldnJump +1#"/>
+    <string name="desc" value="A card that features Barnard Grey.\n#cIf hunting at Kulan Field, Jump+1#"/>
   </imgdir>
   <imgdir name="2382043">
     <string name="name" value="Poopa Card"/>
-    <string name="desc" value="A card that features Poopa.n#cIf hunting at Aqua RoadnSpeed +1#"/>
+    <string name="desc" value="A card that features Poopa.\n#cIf hunting at Aqua Road, Speed+1#"/>
   </imgdir>
   <imgdir name="2382044">
     <string name="name" value="Poison Poopa Card"/>
-    <string name="desc" value="A card that features Poison Poopa.n#cIf hunting at Aqua RoadnDefense against poison-based attacks +3%#"/>
+    <string name="desc" value="A card that features Poison Poopa.\n#cIf hunting at Aqua Road, Defense against poison-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382045">
     <string name="name" value="Chipmunk Card"/>
-    <string name="desc" value="A card that features Chipmunk.n#cIf hunting at Mu LungnSpeed +1#"/>
+    <string name="desc" value="A card that features Chipmunk.\n#cIf hunting at Mu Lung, Speed+1#"/>
   </imgdir>
   <imgdir name="2382046">
     <string name="name" value="Desert Giant Card"/>
-    <string name="desc" value="A card that features Desert Giant.n#cIf hunting at the DesertnSpeed +1#"/>
+    <string name="desc" value="A card that features Desert Giant.\n#cIf hunting at the Desert, Speed+1#"/>
   </imgdir>
   <imgdir name="2382047">
     <string name="name" value="Flyeye"/>
-    <string name="desc" value="A card that features Flyeye.n#cIf hunting at the CavenAvoidability +1#"/>
+    <string name="desc" value="A card that features Flyeye.\n#cIf hunting at the Cave, Avoidability+1#"/>
   </imgdir>
   <imgdir name="2382048">
     <string name="name" value="Robo Card"/>
-    <string name="desc" value="A card that features Robo.n#cIf hunting at the upper floors of the ClocktowernDefense against electric-based attacks +3%#"/>
+    <string name="desc" value="A card that features Robo.\n#cIf hunting at the upper floors of the Clocktower, Defense against electric-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382049">
     <string name="name" value="Platoon Chronos Card"/>
-    <string name="desc" value="A card that features Platoon Chronos.n#cIf hunting at the upper floors of the ClocktowernSpeed +1#"/>
+    <string name="desc" value="A card that features Platoon Chronos.\n#cIf hunting at the upper floors of the Clocktower, Speed+1#"/>
   </imgdir>
   <imgdir name="2382050">
     <string name="name" value="Mateon Card"/>
-    <string name="desc" value="A card that features Mateon.n#cIf hunting at Boswell FieldnThe drop rates for droppings are increased#"/>
+    <string name="desc" value="A card that features Mateon.\n#cIf hunting at Boswell Field, The drop rates for droppings are increased#"/>
   </imgdir>
   <imgdir name="2382051">
     <string name="name" value="Red Porky Card"/>
-    <string name="desc" value="A card that features Red Porky.n#cIf hunting at Mu LungnAvoidability +1#"/>
+    <string name="desc" value="A card that features Red Porky.\n#cIf hunting at Mu Lung, Avoidability+1#"/>
   </imgdir>
   <imgdir name="2382052">
     <string name="name" value="Nependeath Card"/>
-    <string name="desc" value="A card that features Nependeath.n#cIncreases drop rate of Nependeath Honey#"/>
+    <string name="desc" value="A card that features Nependeath.\n#cIncreases drop rate of Nependeath Honey#"/>
   </imgdir>
   <imgdir name="2382053">
     <string name="name" value="Iron Hog Card"/>
-    <string name="desc" value="A card that features Iron Hog.n#cIf hunting at Victoria IslandnJump +1#"/>
+    <string name="desc" value="A card that features Iron Hog.\n#cIf hunting at Victoria Island, Jump+1#"/>
   </imgdir>
   <imgdir name="2382054">
     <string name="name" value="Block Golem"/>
-    <string name="desc" value="A card that features Block Golem.n#cIf hunting at Eos TowernAccuracy +1#"/>
+    <string name="desc" value="A card that features Block Golem.\n#cIf hunting at Eos Tower, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382055">
     <string name="name" value="Zeta Grey Card"/>
-    <string name="desc" value="A card that features Zeta Grey.n#cIf hunting at Kulan FieldnSpeed +1#"/>
+    <string name="desc" value="A card that features Zeta Grey.\n#cIf hunting at Kulan Field, Speed+1#"/>
   </imgdir>
   <imgdir name="2382056">
     <string name="name" value="Freezer Card"/>
-    <string name="desc" value="A card that features Freezer.n#cIf hunting at Aqua RoadnDefense against ice-based attacks +3%#"/>
+    <string name="desc" value="A card that features Freezer.\n#cIf hunting at Aqua Road, Defense against ice-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382057">
     <string name="name" value="Iron Mutae"/>
-    <string name="desc" value="A card that features Iron Mutae.n#cIf hunting at the Alcadno InstitutenSpeed +1#"/>
+    <string name="desc" value="A card that features Iron Mutae.\n#cIf hunting at the Alcadno Institute, Speed+1#"/>
   </imgdir>
   <imgdir name="2382058">
     <string name="name" value="Jr. Cerebes Card"/>
-    <string name="desc" value="A card that features Jr. Cerebes.n#cIf hunting at Dead MinenJump +1#"/>
+    <string name="desc" value="A card that features Jr. Cerebes.\n#cIf hunting at Dead Mine, Jump+1#"/>
   </imgdir>
   <imgdir name="2382059">
     <string name="name" value="Sparker Card"/>
-    <string name="desc" value="A card that features Sparker.n#cIf hunting at Aqua RoadnDefense against electric-based attacks +3%#"/>
+    <string name="desc" value="A card that features Sparker.\n#cIf hunting at Aqua Road, Defense against electric-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382060">
     <string name="name" value="Black Porky Card"/>
-    <string name="desc" value="A card that features Black Porky.n#cIf hunting at Mu LungnAvoidability +1#"/>
+    <string name="desc" value="A card that features Black Porky.\n#cIf hunting at Mu Lung, Avoidability+1#"/>
   </imgdir>
   <imgdir name="2382061">
     <string name="name" value="Plateon Card"/>
-    <string name="desc" value="A card that features Plateon.n#cIf hunting at Boswell FieldnSpeed +1#"/>
+    <string name="desc" value="A card that features Plateon.\n#cIf hunting at Boswell Field, Speed+1#"/>
   </imgdir>
   <imgdir name="2382062">
     <string name="name" value="Master Robo Card"/>
-    <string name="desc" value="A card that features Master Robo.n#cIf hunting at the upper floors of the ClocktowernDefense against electric-based attacks +3%#"/>
+    <string name="desc" value="A card that features Master Robo.\n#cIf hunting at the upper floors of the Clocktower, Defense against electric-based attacks+3%#"/>
   </imgdir>
   <imgdir name="2382063">
     <string name="name" value="Skeledog Card"/>
-    <string name="desc" value="A card that features Skeledog.n#cIf hunting at PerionnSpeed +1#"/>
+    <string name="desc" value="A card that features Skeledog.\n#cIf hunting at Perion, Speed+1#"/>
   </imgdir>
   <imgdir name="2382064">
     <string name="name" value="Lunar Pixie Card"/>
-    <string name="desc" value="A card that features Lunar Pixie.n#cIf hunting at the Cloud ParknJump +1#"/>
+    <string name="desc" value="A card that features Lunar Pixie.\n#cIf hunting at the Cloud Park, Jump+1#"/>
   </imgdir>
   <imgdir name="2382065">
     <string name="name" value="Copper Drake Card"/>
-    <string name="desc" value="A card that features Copper Drake.n#cIf hunting at Victoria IslandnSpeed +1#"/>
+    <string name="desc" value="A card that features Copper Drake.\n#cIf hunting at Victoria Island, Speed+1#"/>
   </imgdir>
   <imgdir name="2382066">
     <string name="name" value="King Block Golem Card"/>
-    <string name="desc" value="A card that features King Block Golem.n#cIf hunting at Eos TowernAccuracy +1#"/>
+    <string name="desc" value="A card that features King Block Golem.\n#cIf hunting at Eos Tower, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382067">
     <string name="name" value="Ultra Grey Card"/>
-    <string name="desc" value="A card that features Ultra Grey.n#cIf hunting at Kulan FieldnAvoidability +1#"/>
+    <string name="desc" value="A card that features Ultra Grey.\n#cIf hunting at Kulan Field, Avoidability+1#"/>
   </imgdir>
   <imgdir name="2382068">
     <string name="name" value="Moon Bunny Card"/>
-    <string name="desc" value="A card that features Moon Bunny.n#cIf hunting at the Black MountainnJump +1#"/>
+    <string name="desc" value="A card that features Moon Bunny.\n#cIf hunting at the Black Mountain, Jump+1#"/>
   </imgdir>
   <imgdir name="2382069">
     <string name="name" value="Iron Boar Card"/>
-    <string name="desc" value="A card that features Iron Boar.n#cIf hunting at Victoria IslandnAccuracy +1#"/>
+    <string name="desc" value="A card that features Iron Boar.\n#cIf hunting at Victoria Island, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382070">
     <string name="name" value="Blue Flower Serpent"/>
-    <string name="desc" value="A card that features Blue Flower Serpent.n#cIf hunting at Mu LungnAvoidability +1#"/>
+    <string name="desc" value="A card that features Blue Flower Serpent.\n#cIf hunting at Mu Lung, Avoidability+1#"/>
   </imgdir>
   <imgdir name="2382071">
     <string name="name" value="Red Flower Serpent"/>
-    <string name="desc" value="A card that features Red Flower Serpent.n#cIf hunting at Mu LungnAvoidability +1#"/>
+    <string name="desc" value="A card that features Red Flower Serpent.\n#cIf hunting at Mu Lung, Avoidability+1#"/>
   </imgdir>
   <imgdir name="2382072">
     <string name="name" value="Reinforced Iron Mutae"/>
-    <string name="desc" value="A card that features Reinforced Iron Mutae.n#cIf hunting at the Alcadno InstitutenAccuracy +1#"/>
+    <string name="desc" value="A card that features Reinforced Iron Mutae.\n#cIf hunting at the Alcadno Institute, Accuracy+1#"/>
   </imgdir>
   <imgdir name="2382076">
     <string name="name" value="Mossy Snail Card"/>
-    <string name="desc" value="A picture of Mossy Snail is on this card.n#cWhile hunting in Ellin ForestnAccuracy +1"/>
+    <string name="desc" value="A picture of Mossy Snail is on this card.\n#cWhile hunting in Ellin Forest, Accuracy+1"/>
   </imgdir>
   <imgdir name="2383000">
     <string name="name" value="Mecateon Card"/>
-    <string name="desc" value="A card that features Mecateon..n#cIf hunting at Boswell FieldnSpeed +2#"/>
+    <string name="desc" value="A card that features Mecateon.\n#cIf hunting at Boswell Field, Speed+2#"/>
   </imgdir>
   <imgdir name="2383001">
     <string name="name" value="Tortie Card"/>
-    <string name="desc" value="A card that features Tortie Card.n#cIf hunting at Florina BeachnAccuracy +2#"/>
+    <string name="desc" value="A card that features Tortie.\n#cIf hunting at Florina Beach, Accuracy+2#"/>
   </imgdir>
   <imgdir name="2383002">
     <string name="name" value="Master Chronos Card"/>
-    <string name="desc" value="A card that features Master Chronos.n#cIf hunting at the upper floors of the ClocktowernJump +2#"/>
+    <string name="desc" value="A card that features Master Chronos.\n#cIf hunting at the upper floors of the Clocktower, Jump+2#"/>
   </imgdir>
   <imgdir name="2383003">
     <string name="name" value="Dark Nependeath Card"/>
-    <string name="desc" value="A card that features Dark Nependeath.n#cIf hunting at the Cloud ParknIncreases drop rate of Nependeath Honey#"/>
+    <string name="desc" value="A card that features Dark Nependeath.\n#cIf hunting at the Cloud Park, Increases drop rate of Nependeath Honey#"/>
   </imgdir>
   <imgdir name="2383004">
     <string name="name" value="Rombot Card"/>
-    <string name="desc" value="A card that features Rombot.n#cIf hunting at Eos TowernItem drop rates are increased#"/>
+    <string name="desc" value="A card that features Rombot.\n#cIf hunting at Eos Tower, Item drop rates are increased#"/>
   </imgdir>
   <imgdir name="2383005">
     <string name="name" value="Mummy Dog Card"/>
-    <string name="desc" value="A card that features Mummy Dog.n#cIf hunting at PerionnJump +2#"/>
+    <string name="desc" value="A card that features Mummy Dog.\n#cIf hunting at Perion, Jump+2#"/>
   </imgdir>
   <imgdir name="2383006">
     <string name="name" value="Jar Card"/>
-    <string name="desc" value="A card that features Jar.n#cIf hunting at Herb Townn#cItem drop rates are increased#"/>
+    <string name="desc" value="A card that features Jar.\n#cIf hunting at Herb Town, Item drop rates are increased#"/>
   </imgdir>
   <imgdir name="2383007">
     <string name="name" value="Mithril Mutae Card"/>
-    <string name="desc" value="A card that features Mithril Mutae.n#cIf hunting at the Alcadno InstitutenAccuracy +2#"/>
+    <string name="desc" value="A card that features Mithril Mutae.\n#cIf hunting at the Alcadno Institute, Accuracy+2#"/>
   </imgdir>
   <imgdir name="2383008">
     <string name="name" value="Wraith Card"/>
-    <string name="desc" value="A card that features Wraith.n#cIf hunting at the SubwaynSpeed +2#"/>
+    <string name="desc" value="A card that features Wraith.\n#cIf hunting at the Subway, Speed+2#"/>
   </imgdir>
   <imgdir name="2383009">
     <string name="name" value="Clang Card"/>
-    <string name="desc" value="A card that features Clang.n#cIf hunting at Florina BeachnSpeed +2#"/>
+    <string name="desc" value="A card that features Clang.\n#cIf hunting at Florina Beach, Speed+2#"/>
   </imgdir>
   <imgdir name="2383010">
     <string name="name" value="Ginseng Jar"/>
-    <string name="desc" value="A card that features Ginseng Jar.n#cIf hunting at Herb TownnThe &quot;Use&quot; item drop rates are increased#"/>
+    <string name="desc" value="A card that features Ginseng Jar.\n#cIf hunting at Herb Town, The &quot;Use&quot; item drop rates are increased#"/>
   </imgdir>
   <imgdir name="2383011">
     <string name="name" value="Chief Grey Card"/>
-    <string name="desc" value="A card that features Chief Grey.n#cIf hunting at Kulan FieldnAccuracy +2#"/>
+    <string name="desc" value="A card that features Chief Grey.\n#cIf hunting at Kulan Field, Accuracy+2#"/>
   </imgdir>
   <imgdir name="2383012">
     <string name="name" value="Drake Card"/>
-    <string name="desc" value="A card that features Drake.n#cIf hunting at Victoria IslandnSpeed +2#"/>
+    <string name="desc" value="A card that features Drake.\n#cIf hunting at Victoria Island, Speed+2#"/>
   </imgdir>
   <imgdir name="2383013">
     <string name="name" value="Jr. Yeti Card"/>
-    <string name="desc" value="A card that features Jr. Yeti.n#If hunting at the SnowfieldnCancels out damage penalty#"/>
+    <string name="desc" value="A card that features Jr. Yeti.\n#If hunting at the Snowfield, Cancels out damage penalty#"/>
   </imgdir>
   <imgdir name="2383014">
     <string name="name" value="Hodori Card"/>
-    <string name="desc" value="A card that features Hodori.n#cIf hunting at the Black MountainnSpeed +2#"/>
+    <string name="desc" value="A card that features Hodori.\n#cIf hunting at the Black Mountain, Speed+2#"/>
   </imgdir>
   <imgdir name="2383015">
     <string name="name" value="Straw Target Dummy"/>
-    <string name="desc" value="A card that features Straw Target Dummy.n#cIf hunting at the Training FieldnAvoidability +2#"/>
+    <string name="desc" value="A card that features Straw Target Dummy.\n#cIf hunting at the Training Field, Avoidability+2#"/>
   </imgdir>
   <imgdir name="2383016">
     <string name="name" value="Reinforced Mithril Mutae"/>
-    <string name="desc" value="A card that features Reinforced Mithril Mutae.n#cIf hunting at the Alcadno InstitutenAvoidability +2#"/>
+    <string name="desc" value="A card that features Reinforced Mithril Mutae.\n#cIf hunting at the Alcadno Institute, Avoidability+2#"/>
   </imgdir>
   <imgdir name="2383017">
     <string name="name" value="Firebomb Card"/>
-    <string name="desc" value="A card that features Firebomb.n#cIf hunting at Dead MinenDefense against fire-based attacks +6%#"/>
+    <string name="desc" value="A card that features Firebomb.\n#cIf hunting at Dead Mine, Defense against fire-based attacks+6%#"/>
   </imgdir>
   <imgdir name="2383018">
     <string name="name" value="Wooden Target Dummy"/>
-    <string name="desc" value="A card that features Wooden Target Dummy.n#cIf hunting at the Training FieldnAccuracy +2#"/>
+    <string name="desc" value="A card that features Wooden Target Dummy.\n#cIf hunting at the Training Field, Accuracy+2#"/>
   </imgdir>
   <imgdir name="2383019">
     <string name="name" value="Croco Card"/>
-    <string name="desc" value="A card that features Croco.n#cIf hunting at the SwampnAvoidability +2#"/>
+    <string name="desc" value="A card that features Croco.\n#cIf hunting at the Swamp, Avoidability+2#"/>
   </imgdir>
   <imgdir name="2383020">
     <string name="name" value="Luster Pixie Card"/>
-    <string name="desc" value="A card that features Luster Pixie.n#cIf hunting at Cloud ParknAccuracy +2#"/>
+    <string name="desc" value="A card that features Luster Pixie.\n#cIf hunting at Cloud Park, Accuracy+2#"/>
   </imgdir>
   <imgdir name="2383021">
     <string name="name" value="Cellion Card"/>
-    <string name="desc" value="A card that features Cellion Card.n#cIf hunting at the Orbis GardennDefense against fire-based attacks +6%#"/>
+    <string name="desc" value="A card that features Cellion.\n#cIf hunting at the Orbis Garden, Defense against fire-based attacks+6%#"/>
   </imgdir>
   <imgdir name="2383022">
     <string name="name" value="Lioner Card"/>
-    <string name="desc" value="A card that features Lioner.n#cIf hunting at the Orbis GardennDefense against electric-based attacks +6%#"/>
+    <string name="desc" value="A card that features Lioner.\n#cIf hunting at the Orbis Garden, Defense against electric-based attacks+6%#"/>
   </imgdir>
   <imgdir name="2383023">
     <string name="name" value="Grupin Card"/>
-    <string name="desc" value="A card that features Grupin.n#cIf hunting at the Orbis GardennDefense against ice-based attacks +6%#"/>
+    <string name="desc" value="A card that features Grupin.\n#cIf hunting at the Orbis Garden, Defense against ice-based attacks+6%#"/>
   </imgdir>
   <imgdir name="2383024">
     <string name="name" value="Hogul"/>
-    <string name="desc" value="A card that features Hogul.n#cIf hunting at the Black MountainnProtection against being knocked out +10%#"/>
+    <string name="desc" value="A card that features Hogul.\n#cIf hunting at the Black Mountain, Protection against being knocked out+10%#"/>
   </imgdir>
   <imgdir name="2383025">
     <string name="name" value="Bellflower Root Card"/>
-    <string name="desc" value="A card that features Bellflower Root.n#cIf hunting at Herb TownnJump +2#"/>
+    <string name="desc" value="A card that features Bellflower Root.\n#cIf hunting at Herb Town, Jump+2#"/>
   </imgdir>
   <imgdir name="2383026">
     <string name="name" value="MT-09 Card"/>
-    <string name="desc" value="A card that features MT-09.n#cIf hunting at Kulan FieldnAccuracy +2#"/>
+    <string name="desc" value="A card that features MT-09.\n#cIf hunting at Kulan Field, Accuracy+2#"/>
   </imgdir>
   <imgdir name="2383027">
     <string name="name" value="Sr. Bellflower Root Card"/>
-    <string name="desc" value="A card that features Sr. Bellflower Root.n#cIf hunting at Herb TownnJump +2#"/>
+    <string name="desc" value="A card that features Sr. Bellflower Root.\n#cIf hunting at Herb Town, Jump+2#"/>
   </imgdir>
   <imgdir name="2383028">
     <string name="name" value="Roid Card"/>
-    <string name="desc" value="A card that features Roid Card.n#cIf hunting at the Alcadno InstitutenDefense against electric-based attacks +6%#"/>
+    <string name="desc" value="A card that features Roid.\n#cIf hunting at the Alcadno Institute, Defense against electric-based attacks+6%#"/>
   </imgdir>
   <imgdir name="2383029">
     <string name="name" value="Malady Card"/>
-    <string name="desc" value="A card that features Malady.n#cIf hunting at EllinianSpeed +2#"/>
+    <string name="desc" value="A card that features Malady.\n#cIf hunting at Ellinia, Speed+2#"/>
   </imgdir>
   <imgdir name="2383030">
     <string name="name" value="Stone Golem Card"/>
-    <string name="desc" value="A card that features Stone Golem.n#cIf hunting at Victoria IslandnAccuracy +2#"/>
+    <string name="desc" value="A card that features Stone Golem.\n#cIf hunting at Victoria Island, Accuracy+2#"/>
   </imgdir>
   <imgdir name="2383031">
     <string name="name" value="Hector Card"/>
-    <string name="desc" value="A card that features Hector Card.n#cIf hunting at the SnowfieldnSpeed +2#"/>
+    <string name="desc" value="A card that features Hector Card.\n#cIf hunting at the Snowfield, Speed+2#"/>
   </imgdir>
   <imgdir name="2383032">
     <string name="name" value="The Book Ghost Card"/>
-    <string name="desc" value="A card that features the Book Ghost.n#cIf hunting at Mu LungnAvoidability +2#"/>
+    <string name="desc" value="A card that features the Book Ghost.\n#cIf hunting at Mu Lung, Avoidability+2#"/>
   </imgdir>
   <imgdir name="2383033">
     <string name="name" value="Dark Jr. Yeti Card"/>
-    <string name="desc" value="A card that features Dark Jr. Yeti.n#cIf hunting at the SnowfieldnCancels out the damage penalty#"/>
+    <string name="desc" value="A card that features Dark Jr. Yeti.\n#cIf hunting at the Snowfield, Cancels out the damage penalty#"/>
   </imgdir>
   <imgdir name="2383034">
     <string name="name" value="Tri-Tailed Fox Card"/>
-    <string name="desc" value="A card that features Tri-Tailed Fox.n#cIf hunting at the Black MountainnDefense against curse +10%#"/>
+    <string name="desc" value="A card that features Tri-Tailed Fox.\n#cIf hunting at the Black Mountain, Defense against curse+10%#"/>
   </imgdir>
   <imgdir name="2383035">
     <string name="name" value="Grizzly Card"/>
-    <string name="desc" value="A card that features Grizzly.n#If hunting at Mu LungnJump +2#"/>
+    <string name="desc" value="A card that features Grizzly.\n#If hunting at Mu Lung, Jump+2#"/>
   </imgdir>
   <imgdir name="2383036">
     <string name="name" value="Skeleton Soldier"/>
-    <string name="desc" value="A card that features Skeleton Soldier.n#cIf hunting at PerionnAvoidability +2#"/>
+    <string name="desc" value="A card that features Skeleton Soldier.\n#cIf hunting at Perion, Avoidability+2#"/>
   </imgdir>
   <imgdir name="2383037">
     <string name="name" value="Coolie Zombie Card"/>
-    <string name="desc" value="A card that features Coolie Zombie Card.n#cIf hunting at El NathnDefense against poison-based attacks +6%#"/>
+    <string name="desc" value="A card that features Coolie Zombie.\n#cIf hunting at El Nath, Defense against poison-based attacks+6%#"/>
   </imgdir>
   <imgdir name="2383038">
     <string name="name" value="Miner Zombie"/>
-    <string name="desc" value="A card that features Miner Zombie.n#cIf hunting at El NathnDefense against poison-based attacks +6%#"/>
+    <string name="desc" value="A card that features Miner Zombie.\n#cIf hunting at El Nath, Defense against poison-based attacks+6%#"/>
   </imgdir>
   <imgdir name="2383039">
     <string name="name" value="Dark Stone Golem"/>
-    <string name="desc" value="A card that features Dark Stone Golem.n#cIf hunting at Victoria IslandnAccuracy +2#"/>
+    <string name="desc" value="A card that features Dark Stone Golem.\n#cIf hunting at Victoria Island, Accuracy+2#"/>
   </imgdir>
   <imgdir name="2383040">
     <string name="name" value="White Fang Card"/>
-    <string name="desc" value="A card that features White Fang.n#cIf hunting at the SnowfieldnSpeed +2#"/>
+    <string name="desc" value="A card that features White Fang.\n#cIf hunting at the Snowfield, Speed+2#"/>
   </imgdir>
   <imgdir name="2383041">
     <string name="name" value="Reindeer Card"/>
-    <string name="desc" value="A card that features Reindeer.n#cIf hunting at Mu LungnJump +2#"/>
+    <string name="desc" value="A card that features Reindeer.\n#cIf hunting at Mu Lung, Jump+2#"/>
   </imgdir>
   <imgdir name="2383042">
     <string name="name" value="Neo Huroid Card"/>
-    <string name="desc" value="A card that features Neo Huroid.n#cIf hunting at the Alcadno InstitutenDefense against electric-based attacks +6%#"/>
+    <string name="desc" value="A card that features Neo Huroid.\n#cIf hunting at the Alcadno Institute, Defense against electric-based attacks+6%#"/>
   </imgdir>
   <imgdir name="2383043">
     <string name="name" value="Mixed Golem Card"/>
-    <string name="desc" value="A card that features Mixed Golem.n#cIf hunting at Victoria IslandnAccuracy +2/Avoidability +2#"/>
+    <string name="desc" value="A card that features Mixed Golem.\n#cIf hunting at Victoria Island, Accuracy+2/Avoidability+2#"/>
   </imgdir>
   <imgdir name="2383044">
     <string name="name" value="Red Drake Card"/>
-    <string name="desc" value="A card that features Red Drake.n#cIf hunting at Victoria IslandnDefense against fire-based attacks +6%#"/>
+    <string name="desc" value="A card that features Red Drake.\n#cIf hunting at Victoria Island, Defense against fire-based attacks+6%#"/>
   </imgdir>
   <imgdir name="2383045">
     <string name="name" value="Pepe Card"/>
-    <string name="desc" value="A card that features Pepe.n#cIf hunting at the SnowfieldnSpeed +2#"/>
+    <string name="desc" value="A card that features Pepe.\n#cIf hunting at the Snowfield, Speed+2#"/>
   </imgdir>
   <imgdir name="2383046">
     <string name="name" value="Blin Card"/>
-    <string name="desc" value="A card that features Blin.n#cIf hunting at the Black MountainnAvoidability +2#"/>
+    <string name="desc" value="A card that features Blin.\n#cIf hunting at the Black Mountain, Avoidability+2#"/>
   </imgdir>
   <imgdir name="2383047">
     <string name="name" value="Panda Card"/>
-    <string name="desc" value="A card that features Panda.n#cIf hunting at Mu LungnDefense against weakness +10%#"/>
+    <string name="desc" value="A card that features Panda.\n#cIf hunting at Mu Lung, Defense against weakness+10%#"/>
   </imgdir>
   <imgdir name="2383048">
     <string name="name" value="Shade Card"/>
-    <string name="desc" value="A card that features Shade.n#cIf hunting at the SubwaynAvoidability +2#"/>
+    <string name="desc" value="A card that features Shade.\n#cIf hunting at the Subway, Avoidability+2#"/>
   </imgdir>
   <imgdir name="2383049">
     <string name="name" value="Master Dummy Card"/>
-    <string name="desc" value="A card that features Master Dummy.n#cIf hunting at Mu Lung Training GroundnAvoidability +2#"/>
+    <string name="desc" value="A card that features Master Dummy.\n#cIf hunting at Mu Lung Training Ground, Avoidability+2#"/>
   </imgdir>
   <imgdir name="2383056">
     <string name="name" value="Tree Rod Card"/>
-    <string name="desc" value="A picture of Tree Rod is on this card.n#cWhile hunting in Ellin ForestnAvoidability +2#"/>
+    <string name="desc" value="A picture of Tree Rod is on this card.\n#cWhile hunting in Ellin Forest, Avoidability+2#"/>
   </imgdir>
   <imgdir name="2383057">
     <string name="name" value="Mossy Mushroom Card"/>
-    <string name="desc" value="A picture of Mossy Mushroom is on this card.n#cWhile hunting in Ellin ForestnJump +2#"/>
+    <string name="desc" value="A picture of Mossy Mushroom is on this card.\n#cWhile hunting in Ellin Forest, Jump+2#"/>
   </imgdir>
   <imgdir name="2383058">
     <string name="name" value="Primitive Boar Card"/>
-    <string name="desc" value="A picture of Primitive Boar is on this card.n#cWhile hunting in Ellin ForestnSpeed +2#"/>
+    <string name="desc" value="A picture of Primitive Boar is on this card.\n#cWhile hunting in Ellin Forest, Speed+2#"/>
   </imgdir>
   <imgdir name="2383059">
     <string name="name" value="Stone Bug Card"/>
-    <string name="desc" value="A picture of Stone Bug is on this card.n#cWhile hunting in Ellin ForestnAccuracy +2#"/>
+    <string name="desc" value="A picture of Stone Bug is on this card.\n#cWhile hunting in Ellin Forest, Accuracy+2#"/>
   </imgdir>
   <imgdir name="2384000">
     <string name="name" value="Buffy Card"/>
-    <string name="desc" value="A card that features Buffy.n#cIf hunting at the lower levels of the ClocktowernJump +3#"/>
+    <string name="desc" value="A card that features Buffy.\n#cIf hunting at the lower levels of the Clocktower, Jump+3#"/>
   </imgdir>
   <imgdir name="2384001">
     <string name="name" value="Wild Cargo Card"/>
-    <string name="desc" value="A card that features Wild Cargo.n#cIf hunting at Victoria IslandnJump +3#"/>
+    <string name="desc" value="A card that features Wild Cargo.\n#cIf hunting at Victoria Island, Jump+3#"/>
   </imgdir>
   <imgdir name="2384002">
     <string name="name" value="Peach Monkey Card"/>
-    <string name="desc" value="A card that features Peach Monkey.n#cIf hunting at Mu LungnAccuracy +3#"/>
+    <string name="desc" value="A card that features Peach Monkey.\n#cIf hunting at Mu Lung, Accuracy+3#"/>
   </imgdir>
   <imgdir name="2384003">
     <string name="name" value="Officer Skeleton Card"/>
-    <string name="desc" value="A card that features Officer Skeleton.n#cIf hunting at PerionnAvoidability +3#"/>
+    <string name="desc" value="A card that features Officer Skeleton.\n#cIf hunting at Perion, Avoidability+3#"/>
   </imgdir>
   <imgdir name="2384004">
     <string name="name" value="Soul Teddy Card"/>
-    <string name="desc" value="A card that features Soul Teddy.n#cIf hunting at the lower levels of the ClocktowernAvoidability +3#"/>
+    <string name="desc" value="A card that features Soul Teddy.\n#cIf hunting at the lower levels of the Clocktower, Avoidability+3#"/>
   </imgdir>
   <imgdir name="2384005">
     <string name="name" value="Jr. Luinel Card"/>
-    <string name="desc" value="A card that features Jr. Luinel.n#cIf hunting at the Orbis GardennDefense against darkness +15%#"/>
+    <string name="desc" value="A card that features Jr. Luinel.\n#cIf hunting at the Orbis Garden, Defense against darkness+15%#"/>
   </imgdir>
   <imgdir name="2384006">
     <string name="name" value="Ice Drake Card"/>
-    <string name="desc" value="A card that features Ice Drake.n#cIf hunting at Victoria IslandnDefense against ice-based attacks +9%#"/>
+    <string name="desc" value="A card that features Ice Drake.\n#cIf hunting at Victoria Island, Defense against ice-based attacks+9%#"/>
   </imgdir>
   <imgdir name="2384007">
     <string name="name" value="Dark Pepe Card"/>
-    <string name="desc" value="A card that features Dark Pepe.n#cIf hunting at the SnowfieldnSpeed +3#"/>
+    <string name="desc" value="A card that features Dark Pepe.\n#cIf hunting at the Snowfield, Speed+3#"/>
   </imgdir>
   <imgdir name="2384008">
     <string name="name" value="Mr. Alli Card"/>
-    <string name="desc" value="A card that features Mr. Alli.n#cIf hunting at Herb TownnProtection against being knocked out +15%#"/>
+    <string name="desc" value="A card that features Mr. Alli.\n#cIf hunting at Herb Town, Protection against being knocked out+15%#"/>
   </imgdir>
   <imgdir name="2384009">
     <string name="name" value="Yeti Card"/>
-    <string name="desc" value="A card that features Yeti.n#cIf hunting at the SnowfieldnDefense against ice-based attacks +9%#"/>
+    <string name="desc" value="A card that features Yeti.\n#cIf hunting at the Snowfield, Defense against ice-based attacks+9%#"/>
   </imgdir>
   <imgdir name="2384010">
     <string name="name" value="Riche Card"/>
-    <string name="desc" value="A card that features Riche.n#cIf hunting at the SnowfieldnDefense against seal +15%#"/>
+    <string name="desc" value="A card that features Riche.\n#cIf hunting at the Snowfield, Defense against seal+15%#"/>
   </imgdir>
   <imgdir name="2384011">
     <string name="name" value="Homun Card"/>
-    <string name="desc" value="A card that features Homun.n#cIf hunting at the Zenumist InstitutenAvoidability +3#"/>
+    <string name="desc" value="A card that features Homun.\n#cIf hunting at the Zenumist Institute, Avoidability+3#"/>
   </imgdir>
   <imgdir name="2384012">
     <string name="name" value="Lazy Buffy Card"/>
-    <string name="desc" value="A card that features Lazy Buffy.n#cIf hunting at the lower levels of the ClocktowernAvoidability +3#"/>
+    <string name="desc" value="A card that features Lazy Buffy.\n#cIf hunting at the lower levels of the Clocktower, Avoidability+3#"/>
   </imgdir>
   <imgdir name="2384013">
     <string name="name" value="Sage Cat Card"/>
-    <string name="desc" value="A card that features Sage Cat.n#cIf hunting at Mu LungnAccuracy +3#"/>
+    <string name="desc" value="A card that features Sage Cat.\n#cIf hunting at Mu Lung, Accuracy+3#"/>
   </imgdir>
   <imgdir name="2384014">
     <string name="name" value="Master Soul Teddy Card"/>
-    <string name="desc" value="A card that features Master Soul Teddy.n#cIf hunting at the lower levels of the ClocktowernAvoidability +3#"/>
+    <string name="desc" value="A card that features Master Soul Teddy.\n#cIf hunting at the lower levels of the Clocktower, Avoidability+3#"/>
   </imgdir>
   <imgdir name="2384015">
     <string name="name" value="Dark Drake Card"/>
-    <string name="desc" value="A card that features Dark Drake.n#cIf hunting at Victoria IslandnDefense against darkness +15%#"/>
+    <string name="desc" value="A card that features Dark Drake.\n#cIf hunting at Victoria Island, Defense against darkness+15%#"/>
   </imgdir>
   <imgdir name="2384016">
     <string name="name" value="Dark Yeti Card"/>
-    <string name="desc" value="A card that features Dark Yeti.n#cIf hunting at the SnowfieldnDefense against ice-based attacks +9%#"/>
+    <string name="desc" value="A card that features Dark Yeti.\n#cIf hunting at the Snowfield, Defense against ice-based attacks+9%#"/>
   </imgdir>
   <imgdir name="2384017">
     <string name="name" value="Kru Card"/>
-    <string name="desc" value="A card that features Kru.n#cIf hunting at Herb TownnSpeed +3#"/>
+    <string name="desc" value="A card that features Kru.\n#cIf hunting at Herb Town, Speed+3#"/>
   </imgdir>
   <imgdir name="2384018">
     <string name="name" value="Cyti Card"/>
-    <string name="desc" value="A card that features Cyti.n#cIf hunting at the labnAvoidability +3#"/>
+    <string name="desc" value="A card that features Cyti.\n#cIf hunting at the lab, Avoidability+3#"/>
   </imgdir>
   <imgdir name="2384019">
     <string name="name" value="Klock Card"/>
-    <string name="desc" value="A card that features Klock.n#cIf hunting at the lower levels of the ClocktowernAccuracy +3#"/>
+    <string name="desc" value="A card that features Klock.\n#cIf hunting at the lower levels of the Clocktower, Accuracy+3#"/>
   </imgdir>
   <imgdir name="2384020">
     <string name="name" value="Tauromacis Card"/>
-    <string name="desc" value="A card that features Tauromacis.n#cIf hunting at Victoria IslandnDefense against poison-based attacks +9%#"/>
+    <string name="desc" value="A card that features Tauromacis.\n#cIf hunting at Victoria Island, Defense against poison-based attacks+9%#"/>
   </imgdir>
   <imgdir name="2384021">
     <string name="name" value="Yellow King Goblin Card"/>
-    <string name="desc" value="A card that features Yellow King Goblin.n#cIf hunting at the Black MountainnDefense against fire-based attacks +9%#"/>
+    <string name="desc" value="A card that features Yellow King Goblin.\n#cIf hunting at the Black Mountain, Defense against fire-based attacks+9%#"/>
   </imgdir>
   <imgdir name="2384022">
     <string name="name" value="Blue King Goblin Card"/>
-    <string name="desc" value="A card that features Blue King Goblin.n#cIf hunting at the Black MountainnDefense against ice-based attacks +9%#"/>
+    <string name="desc" value="A card that features Blue King Goblin.\n#cIf hunting at the Black Mountain, Defense against ice-based attacks+9%#"/>
   </imgdir>
   <imgdir name="2384023">
     <string name="name" value="Green King Goblin Card"/>
-    <string name="desc" value="A card that features Green King Goblin.n#cIf hunting at the Black MountainnDefense against poison-based attacks +9%#"/>
+    <string name="desc" value="A card that features Green King Goblin.\n#cIf hunting at the Black Mountain, Defense against poison-based attacks+9%#"/>
   </imgdir>
   <imgdir name="2384024">
     <string name="name" value="Rash Card"/>
-    <string name="desc" value="A card that features Rash.n#cIf hunting at Leafre ForestnDefense against curse +15%#"/>
+    <string name="desc" value="A card that features Rash.\n#cIf hunting at Leafre Forest, Defense against curse+15%#"/>
   </imgdir>
   <imgdir name="2384025">
     <string name="name" value="Captain Card"/>
-    <string name="desc" value="A card that features Captain.n#cIf hunting at Herb TownnJump +3#"/>
+    <string name="desc" value="A card that features Captain.\n#cIf hunting at Herb Town, Jump+3#"/>
   </imgdir>
   <imgdir name="2384026">
     <string name="name" value="Cerebes Card"/>
-    <string name="desc" value="A card that features Cerebes.n#cIf hunting at Dead MinenAccuracy +3#"/>
+    <string name="desc" value="A card that features Cerebes.\n#cIf hunting at Dead Mine, Accuracy+3#"/>
   </imgdir>
   <imgdir name="2384027">
     <string name="name" value="Beetle Card"/>
-    <string name="desc" value="A card that features Beetle.n#cIf hunting at Leafre ForestnAvoidability +3#"/>
+    <string name="desc" value="A card that features Beetle.\n#cIf hunting at Leafre Forest, Avoidability+3#"/>
   </imgdir>
   <imgdir name="2384028">
     <string name="name" value="Hobi Card"/>
-    <string name="desc" value="A card that features Hobi.n#cIf hunting at Leafre ForestnDefense against poison-based attack +15%#"/>
+    <string name="desc" value="A card that features Hobi.\n#cIf hunting at Leafre Forest, Defense against poison-based attack+15%#"/>
   </imgdir>
   <imgdir name="2384029">
     <string name="name" value="Commander Skeleton Card"/>
-    <string name="desc" value="A card that features Commander Skeleton.n#cIf hunting at PerionnAccuracy +3/Avoidability +3#"/>
+    <string name="desc" value="A card that features Commander Skeleton.\n#cIf hunting at Perion, Accuracy+3/Avoidability+3#"/>
   </imgdir>
   <imgdir name="2384030">
     <string name="name" value="Luinel Card"/>
-    <string name="desc" value="A card that features Luinel.n#cIf hunting at the Orbis GardennDefense against darkness +15%#"/>
+    <string name="desc" value="A card that features Luinel.\n#cIf hunting at the Orbis Garden, Defense against darkness+15%#"/>
   </imgdir>
   <imgdir name="2384031">
     <string name="name" value="Homunculu Card"/>
-    <string name="desc" value="A card that features Homunculu.n#cIf hunting at the Zenumist InstitutenAvoidability +3#"/>
+    <string name="desc" value="A card that features Homunculu.\n#cIf hunting at the Zenumist Institute, Avoidability+3#"/>
   </imgdir>
   <imgdir name="2384032">
     <string name="name" value="Buffoon Card"/>
-    <string name="desc" value="A card that features Buffoon.n#cIf hunting at the lower levels of the ClocktowernSpeed +3#"/>
+    <string name="desc" value="A card that features Buffoon.\n#cIf hunting at the lower levels of the Clocktower, Speed+3#"/>
   </imgdir>
   <imgdir name="2384033">
     <string name="name" value="Dark Rash Card"/>
-    <string name="desc" value="A card that features Dark Rash.n#cIf hunting at Leafre ForestnDefense against curse +15%#"/>
+    <string name="desc" value="A card that features Dark Rash.\n#cIf hunting at Leafre Forest, Defense against curse+15%#"/>
   </imgdir>
   <imgdir name="2384034">
     <string name="name" value="D.Roy Card"/>
-    <string name="desc" value="A card that features D. Roy.n#cIf hunting at the Alcadno InstitutenAccuracy +3/Avoidability +3#"/>
+    <string name="desc" value="A card that features D. Roy.\n#cIf hunting at the Alcadno Institute, Accuracy+3/Avoidability+3#"/>
   </imgdir>
   <imgdir name="2384035">
     <string name="name" value="Werewolf Card"/>
-    <string name="desc" value="A card that features Werewolf.n#cIf hunting at the SnowfieldnAccuracy +3#"/>
+    <string name="desc" value="A card that features Werewolf.\n#cIf hunting at the Snowfield, Accuracy+3#"/>
   </imgdir>
   <imgdir name="2384036">
     <string name="name" value="Taurospear Card"/>
-    <string name="desc" value="A card that features Taurospear.n#cIf hunting at Victoria IslandnAccuracy +3#"/>
+    <string name="desc" value="A card that features Taurospear.\n#cIf hunting at Victoria Island, Accuracy+3#"/>
   </imgdir>
   <imgdir name="2384037">
     <string name="name" value="Snow Witch Card"/>
-    <string name="desc" value="A card that features Snow Witch.n#cIf hunting at the SnowfieldnDefense against ice-based attacks +9%#"/>
+    <string name="desc" value="A card that features Snow Witch.\n#cIf hunting at the Snowfield, Defense against ice-based attacks+9%#"/>
   </imgdir>
   <imgdir name="2384038">
     <string name="name" value="Security Camera Card"/>
-    <string name="desc" value="A card that features Security Camera.n#cIf hunting at the Alcadno InstitutenSpeed +3#"/>
+    <string name="desc" value="A card that features Security Camera.\n#cIf hunting at the Alcadno Institute, Speed+3#"/>
   </imgdir>
   <imgdir name="2384039">
     <string name="name" value="Scholar Ghost Card"/>
-    <string name="desc" value="A card that features Scholar Ghost.n#cIf hunting at the Black MountainnItem drop rate increased#"/>
+    <string name="desc" value="A card that features Scholar Ghost.\n#cIf hunting at the Black Mountain, Item drop rate increased#"/>
   </imgdir>
   <imgdir name="2384040">
     <string name="name" value="Rurumo Card"/>
-    <string name="desc" value="A card that features Rurumo.n#cIf hunting at the Alcadno InstitutenItem drop rate increased#"/>
+    <string name="desc" value="A card that features Rurumo.\n#cIf hunting at the Alcadno Institute, Item drop rate increased#"/>
   </imgdir>
   <imgdir name="2385000">
     <string name="name" value="Dark Klock Card"/>
-    <string name="desc" value="A card that features Dark Klock.n#cIf hunting at the lower levels of the ClocktowernAvoidability +4#"/>
+    <string name="desc" value="A card that features Dark Klock.\n#cIf hunting at the lower levels of the Clocktower, Avoidability+4#"/>
   </imgdir>
   <imgdir name="2385001">
     <string name="name" value="Dual Beetle Card"/>
-    <string name="desc" value="A card that features Dual Beetle.n#cIf hunting at Leafre ForestnAvoidability +4#"/>
+    <string name="desc" value="A card that features Dual Beetle.\n#cIf hunting at Leafre Forest, Avoidability+4#"/>
   </imgdir>
   <imgdir name="2385002">
     <string name="name" value="Green Hobi Card"/>
-    <string name="desc" value="A card that features Green Hobi.n#cIf hunting at Minar ForestnAccuracy +4/Avoidability +4#"/>
+    <string name="desc" value="A card that features Green Hobi.\n#cIf hunting at Minar Forest, Accuracy+4/Avoidability+4#"/>
   </imgdir>
   <imgdir name="2385003">
     <string name="name" value="Deep Buffoon Card"/>
-    <string name="desc" value="A card that features Deep Buffoon.n#cIf hunting at the lower levels of the ClocktowernSpeed +4#"/>
+    <string name="desc" value="A card that features Deep Buffoon.\n#cIf hunting at the lower levels of the Clocktower, Speed+4#"/>
   </imgdir>
   <imgdir name="2385004">
     <string name="name" value="Yeti and Pepe Card"/>
-    <string name="desc" value="A card that features Yeti and Pepe.n#cIf hunting at the SnowfieldnAvoidability +4#"/>
+    <string name="desc" value="A card that features Yeti and Pepe.\n#cIf hunting at the Snowfield, Avoidability+4#"/>
   </imgdir>
   <imgdir name="2385005">
     <string name="name" value="Hankie Card"/>
-    <string name="desc" value="A card that features Hankie.n#cIf hunting at Leafre ForestnJump +4#"/>
+    <string name="desc" value="A card that features Hankie.\n#cIf hunting at Leafre Forest, Jump+4#"/>
   </imgdir>
   <imgdir name="2385006">
     <string name="name" value="Lycanthrope Card"/>
-    <string name="desc" value="A card that features Lycanthrope.n#cIf hunting at the SnowfieldnAccuracy +4#"/>
+    <string name="desc" value="A card that features Lycanthrope.\n#cIf hunting at the Snowfield, Accuracy+4#"/>
   </imgdir>
   <imgdir name="2385007">
     <string name="name" value="Harp Card"/>
-    <string name="desc" value="A card that features Harp.n#cIf hunting at Minar ForestnAvoidability +4#"/>
+    <string name="desc" value="A card that features Harp.\n#cIf hunting at Minar Forest, Avoidability+4#"/>
   </imgdir>
   <imgdir name="2385008">
     <string name="name" value="Homunscullo Card"/>
-    <string name="desc" value="A card that features Homunscullo.n#cIf hunting at the Zenumist InstitutenJump +4#"/>
+    <string name="desc" value="A card that features Homunscullo.\n#cIf hunting at the Zenumist Institute, Jump+4#"/>
   </imgdir>
   <imgdir name="2385009">
     <string name="name" value="Dark Yeti and Pepe Card"/>
-    <string name="desc" value="A card that features Dark Yeti and Pepe.n#cIf hunting at the SnowfieldnAvoidability +4#"/>
+    <string name="desc" value="A card that features Dark Yeti and Pepe.\n#cIf hunting at the Snowfield, Avoidability+4#"/>
   </imgdir>
   <imgdir name="2385010">
     <string name="name" value="Pirate Card"/>
-    <string name="desc" value="A card that features Pirate.n#cIf hunting at the lower levels of the ClocktowernAccuracy +4#"/>
+    <string name="desc" value="A card that features Pirate.\n#cIf hunting at the lower levels of the Clocktower, Accuracy+4#"/>
   </imgdir>
   <imgdir name="2385011">
     <string name="name" value="Blood Harp Card"/>
-    <string name="desc" value="A card that features Blood Harp.n#cIf hunting at Minar ForestnAccuracy +4#"/>
+    <string name="desc" value="A card that features Blood Harp.\n#cIf hunting at Minar Forest, Accuracy+4#"/>
   </imgdir>
   <imgdir name="2385012">
     <string name="name" value="Death Teddy Card"/>
-    <string name="desc" value="A card that features Death Teddy.n#cIf hunting at the lower levels of the ClocktowernAccuracy +4#"/>
+    <string name="desc" value="A card that features Death Teddy.\n#cIf hunting at the lower levels of the Clocktower, Accuracy+4#"/>
   </imgdir>
   <imgdir name="2385013">
     <string name="name" value="Goby Card"/>
-    <string name="desc" value="A card that features Goby.n#cIf hunting at Aqua Roadn15% chance of breaking through the monster&apos;s magic defense#"/>
+    <string name="desc" value="A card that features Goby.\n#cIf hunting at Aqua Road, 15% chance of breaking through the monster&apos;s magic defense#"/>
   </imgdir>
   <imgdir name="2385014">
     <string name="name" value="Birk Card"/>
-    <string name="desc" value="A card that features Birk.n#cIf hunting at Leafre ForestnSpeed +4#"/>
+    <string name="desc" value="A card that features Birk.\n#cIf hunting at Leafre Forest, Speed+4#"/>
   </imgdir>
   <imgdir name="2385015">
     <string name="name" value="Dual Pirate Card"/>
-    <string name="desc" value="A card that features Dual Pirate.n#cIf hunting at the lower levels of the ClocktowernAccuracy +4#"/>
+    <string name="desc" value="A card that features Dual Pirate.\n#cIf hunting at the lower levels of the Clocktower, Accuracy+4#"/>
   </imgdir>
   <imgdir name="2385016">
     <string name="name" value="Black Kentaurus Card"/>
-    <string name="desc" value="A card that features Black Kentaurus.n#cIf hunting at Leafre ForestnDefense against darkness +20%#"/>
+    <string name="desc" value="A card that features Black Kentaurus.\n#cIf hunting at Leafre Forest, Defense against darkness+20%#"/>
   </imgdir>
   <imgdir name="2385017">
     <string name="name" value="Red Kentaurus Card"/>
-    <string name="desc" value="A card that features Red Kentaurus.n#cIf hunting at Leafre ForestnDefense against fire-based attacks +12%#"/>
+    <string name="desc" value="A card that features Red Kentaurus.\n#cIf hunting at Leafre Forest, Defense against fire-based attacks+12%#"/>
   </imgdir>
   <imgdir name="2385018">
     <string name="name" value="Blue Kentaurus Card"/>
-    <string name="desc" value="A card that features Blue Kentaurus.n#cIf hunting at Leafre ForestnDefense against ice-based attacks +12%#"/>
+    <string name="desc" value="A card that features Blue Kentaurus.\n#cIf hunting at Leafre Forest, Defense against ice-based attacks+12%#"/>
   </imgdir>
   <imgdir name="2385019">
     <string name="name" value="Dual Birk Card"/>
-    <string name="desc" value="A card that features Dual Birk.n#cIf hunting at Leafre ForestnSpeed +4#"/>
+    <string name="desc" value="A card that features Dual Birk.\n#cIf hunting at Leafre Forest, Speed+4#"/>
   </imgdir>
   <imgdir name="2385020">
     <string name="name" value="Master Death Teddy Card"/>
-    <string name="desc" value="A card that features Master Death Teddy.n#cIf hunting at the lower levels of the ClocktowernAccuracy +4/Avoidability +4#"/>
+    <string name="desc" value="A card that features Master Death Teddy.\n#cIf hunting at the lower levels of the Clocktower, Accuracy+4/Avoidability+4#"/>
   </imgdir>
   <imgdir name="2385021">
     <string name="name" value="Bain Card"/>
-    <string name="desc" value="A card that features Bain.n#cIf hunting at Dead MinenDefense against fire-based attacks +12%#"/>
+    <string name="desc" value="A card that features Bain.\n#cIf hunting at Dead Mine, Defense against fire-based attacks+12%#"/>
   </imgdir>
   <imgdir name="2385022">
     <string name="name" value="Blue Dragon Turtle Card"/>
-    <string name="desc" value="A card that features Blue Dragon Turtle.n#cIf hunting at the Dragon ForestnAccuracy +4#"/>
+    <string name="desc" value="A card that features Blue Dragon Turtle.\n#cIf hunting at the Dragon Forest, Accuracy+4#"/>
   </imgdir>
   <imgdir name="2385023">
     <string name="name" value="Deet and Roi Card"/>
-    <string name="desc" value="A card that features Deet amd Roi.n#cIf hunting at the Zenumist InstitutenSpeed +4#"/>
+    <string name="desc" value="A card that features Deet and Roi.\n#cIf hunting at the Zenumist Institute, Speed+4#"/>
   </imgdir>
   <imgdir name="2385025">
     <string name="name" value="Eye of Time Card"/>
-    <string name="desc" value="A card with a picture of the Eye of Time.nWhen hunting on the Temple of TimenSpeed +4#"/>
+    <string name="desc" value="A card with a picture of the Eye of Time.\nWhen hunting on the Temple of Time, Speed+4#"/>
   </imgdir>
   <imgdir name="2386000">
     <string name="name" value="Bone Fish Card"/>
-    <string name="desc" value="A card that features Bone Fish.n#cIf hunting at Aqua Roadn30% chance of breaking through monster&apos;s weapon defense#"/>
+    <string name="desc" value="A card that features Bone Fish.\n#cIf hunting at Aqua Road, 30% chance of breaking through monster&apos;s weapon defense#"/>
   </imgdir>
   <imgdir name="2386001">
     <string name="name" value="Red Dragon Turtle Card"/>
-    <string name="desc" value="A card that features Red Dragon Turtle.n#cIf hunting at the Dragon ForestnAvoidability +5#"/>
+    <string name="desc" value="A card that features Red Dragon Turtle.\n#cIf hunting at the Dragon Forest, Avoidability+5#"/>
   </imgdir>
   <imgdir name="2386002">
     <string name="name" value="Viking Card"/>
-    <string name="desc" value="A card that features Viking.n#cIf hunting at the lower levels of the ClocktowernDefense against fire-based attacks +15%#"/>
+    <string name="desc" value="A card that features Viking.\n#cIf hunting at the lower levels of the Clocktower, Defense against fire-based attacks+15%#"/>
   </imgdir>
   <imgdir name="2386003">
     <string name="name" value="Squid Card"/>
-    <string name="desc" value="A card that features Squid.n#cIf hunting at Aqua RoadnDefense against darkness +25%#"/>
+    <string name="desc" value="A card that features Squid.\n#cIf hunting at Aqua Road, Defense against darkness+25%#"/>
   </imgdir>
   <imgdir name="2386004">
     <string name="name" value="Phantom Watch Card"/>
-    <string name="desc" value="A card that features Phantom Watch.n#cIf hunting at the lower levels of the ClocktowernDefense against ice-based attacks +15%#"/>
+    <string name="desc" value="A card that features Phantom Watch.\n#cIf hunting at the lower levels of the Clocktower, Defense against ice-based attacks+15%#"/>
   </imgdir>
   <imgdir name="2386005">
     <string name="name" value="Rexton Card"/>
-    <string name="desc" value="A card that features Rexton.n#cIf hunting at the Dragon ForestnSpeed +5#"/>
+    <string name="desc" value="A card that features Rexton.\n#cIf hunting at the Dragon Forest, Speed+5#"/>
   </imgdir>
   <imgdir name="2386006">
     <string name="name" value="Brexton Card"/>
-    <string name="desc" value="A card that features Brexton.n#cIf hunting at the Dragon ForestnAccuracy +5#"/>
+    <string name="desc" value="A card that features Brexton.\n#cIf hunting at the Dragon Forest, Accuracy+5#"/>
   </imgdir>
   <imgdir name="2386007">
     <string name="name" value="Risell Squid Card"/>
-    <string name="desc" value="A card that features Risell Squid.n#cIf hunting at Aqua RoadnDefense against darkness +25%#"/>
+    <string name="desc" value="A card that features Risell Squid.\n#cIf hunting at Aqua Road, Defense against darkness+25%#"/>
   </imgdir>
   <imgdir name="2386008">
     <string name="name" value="Red Wyvern Card"/>
-    <string name="desc" value="A card that features Red Wyvern.n#cIf hunting at the Dragon ForestnDefense against fire-based attacks +15%#"/>
+    <string name="desc" value="A card that features Red Wyvern.\n#cIf hunting at the Dragon Forest, Defense against fire-based attacks+15%#"/>
   </imgdir>
   <imgdir name="2386009">
     <string name="name" value="Gigantic Viking Card"/>
-    <string name="desc" value="A card that features Gigantic Viking.n#cIf hunting at the lower levels of the ClocktowernDefense against fire-based attacks +15%#"/>
+    <string name="desc" value="A card that features Gigantic Viking.\n#cIf hunting at the lower levels of the Clocktower, Defense against fire-based attacks+15%#"/>
   </imgdir>
   <imgdir name="2386010">
     <string name="name" value="G. Phantom Watch Card"/>
-    <string name="desc" value="A card that features G. Phantom Watch.n#cIf hunting at the lower levels of the ClocktowernDefense against ice-based attacks +15%#"/>
+    <string name="desc" value="A card that features G. Phantom Watch.\n#cIf hunting at the lower levels of the Clocktower, Defense against ice-based attacks+15%#"/>
   </imgdir>
   <imgdir name="2386011">
     <string name="name" value="Green Cornian Card"/>
-    <string name="desc" value="A card that features Green Cornian.n#cIf hunting at the Dragon ForestnSpeed +5#"/>
+    <string name="desc" value="A card that features Green Cornian.\n#cIf hunting at the Dragon Forest, Speed+5#"/>
   </imgdir>
   <imgdir name="2386012">
     <string name="name" value="Shark Card"/>
-    <string name="desc" value="A card that features Sharkn#cIf hunting at Aqua RoadnDefense against ice-based attacks +15%#"/>
+    <string name="desc" value="A card that features Shark\n#cIf hunting at Aqua Road, Defense against ice-based attacks+15%#"/>
   </imgdir>
   <imgdir name="2386013">
     <string name="name" value="Blue Wyvern Card"/>
-    <string name="desc" value="A card that features Blue Wyvern.n#cIf hunting at the Dragon ForestnDefense against ice-based attacks +15%#"/>
+    <string name="desc" value="A card that features Blue Wyvern.\n#cIf hunting at the Dragon Forest, Defense against ice-based attacks+15%#"/>
   </imgdir>
   <imgdir name="2386014">
     <string name="name" value="Cold Shark Card"/>
-    <string name="desc" value="A card that features Cold Shark.n#cIf hunting at Aqua RoadnAccuracy +5#"/>
+    <string name="desc" value="A card that features Cold Shark.\n#cIf hunting at Aqua Road, Accuracy+5#"/>
   </imgdir>
   <imgdir name="2386015">
     <string name="name" value="Dark Wyvern Card"/>
-    <string name="desc" value="A card that features Dark Wyvern.n#cIf hunting at the Dragon ForestnDefense against darkness +25%#"/>
+    <string name="desc" value="A card that features Dark Wyvern.\n#cIf hunting at the Dragon Forest, Defense against darkness+25%#"/>
   </imgdir>
   <imgdir name="2386016">
     <string name="name" value="Dark Cornian Card"/>
-    <string name="desc" value="A card that features Dark Cornian.n#cIf hunting at the Dragon ForestnAccuracy +5#"/>
+    <string name="desc" value="A card that features Dark Cornian.\n#cIf hunting at the Dragon Forest, Accuracy+5#"/>
   </imgdir>
   <imgdir name="2386017">
     <string name="name" value="Jr. Newtie Card"/>
-    <string name="desc" value="A card that features Jr. Newtie.n#cIf hunting at the Dragon ForestnAvoidability +5#"/>
+    <string name="desc" value="A card that features Jr. Newtie.\n#cIf hunting at the Dragon Forest, Avoidability+5#"/>
   </imgdir>
   <imgdir name="2386021">
     <string name="name" value="Memory Monk Card"/>
-    <string name="desc" value="A card with a picture of the Memory Monk.n#cWhen hunting on Memory LanenEvasion rate +5#"/>
+    <string name="desc" value="A card with a picture of the Memory Monk.\n#cWhen hunting on Memory Lane, Evasion rate+5#"/>
   </imgdir>
   <imgdir name="2386022">
     <string name="name" value="Memory Monk Trainee Card"/>
-    <string name="desc" value="A card with a picture of the Memory Monk Trainee.n#cWhen hunting on Memory LanenAccuracy +5#"/>
+    <string name="desc" value="A card with a picture of the Memory Monk Trainee.\n#cWhen hunting on Memory Lane, Accuracy+5#"/>
   </imgdir>
   <imgdir name="2386023">
     <string name="name" value="Memory Guardian Card"/>
-    <string name="desc" value="A card with a picture of the Memory Guardian.n#cWhen hunting on Memory LanenJump +5#"/>
+    <string name="desc" value="A card with a picture of the Memory Guardian.\n#cWhen hunting on Memory Lane, Jump+5#"/>
   </imgdir>
   <imgdir name="2386024">
     <string name="name" value="Chief Memory Guardian Card"/>
-    <string name="desc" value="A card with a picture of the Chief Memory Guardian.n#cWhen hunting on Memory LanenSpeed +5#"/>
+    <string name="desc" value="A card with a picture of the Chief Memory Guardian.\n#cWhen hunting on Memory Lane, Speed+5#"/>
   </imgdir>
   <imgdir name="2387000">
     <string name="name" value="Gatekeeper Card"/>
-    <string name="desc" value="A card that features Gatekeeper.n#If hunting at the lower levels of the Clocktowern25% chance of breaking through monster&apos;s weapon defense#"/>
+    <string name="desc" value="A card that features Gatekeeper.\n#If hunting at the lower levels of the Clocktower, 25% chance of breaking through monster&apos;s weapon defense#"/>
   </imgdir>
   <imgdir name="2387001">
     <string name="name" value="Thanatos Card"/>
-    <string name="desc" value="A card that features Thanatosn#cIf hunting at the lower levels of the Clocktowern25% chance of breaking through monster&apos;s magic defense#"/>
+    <string name="desc" value="A card that features Thanatos.\n#cIf hunting at the lower levels of the Clocktower, 25% chance of breaking through monster&apos;s magic defense#"/>
   </imgdir>
   <imgdir name="2387002">
     <string name="name" value="Skelegon Card"/>
-    <string name="desc" value="A card that features Skelegon.n#cIf hunting at the Dragon ForestnAccuracy +6/Avoidability +6#"/>
+    <string name="desc" value="A card that features Skelegon.\n#cIf hunting at the Dragon Forest, Accuracy+6/Avoidability+6#"/>
   </imgdir>
   <imgdir name="2387003">
     <string name="name" value="Skelosaurus Card"/>
-    <string name="desc" value="A card that features Skelosaurusn#cIf hunting at the Dragon Forestn20% chance of breaking through monster&apos;s weapon/magic defense#"/>
+    <string name="desc" value="A card that features Skelosaurus.\n#cIf hunting at the Dragon Forest, 20% chance of breaking through monster&apos;s weapon/magic defense#"/>
   </imgdir>
   <imgdir name="2387004">
     <string name="name" value="Nest Golem Card"/>
-    <string name="desc" value="A card that features Nest Golem.n#cIf hunting at the Dragon ForestnAccuracy +5"/>
+    <string name="desc" value="A card that features Nest Golem.\n#cIf hunting at the Dragon Forest, Accuracy+5"/>
   </imgdir>
   <imgdir name="2387006">
     <string name="name" value="Qualm Monk Card"/>
-    <string name="desc" value="A card with a picture of the Qualm Monk.n#cWhen hunting on the Road of RegretsnEvasion rate +6#"/>
+    <string name="desc" value="A card with a picture of the Qualm Monk.\n#cWhen hunting on the Road of Regrets, Evasion rate+6#"/>
   </imgdir>
   <imgdir name="2387007">
     <string name="name" value="Qualm Monk Trainee Card"/>
-    <string name="desc" value="A card with a picture of the Qualm Monk Trainee.n#cWhen hunting on the Road of RegretsnAccuracy +6#"/>
+    <string name="desc" value="A card with a picture of the Qualm Monk Trainee.\n#cWhen hunting on the Road of Regrets, Accuracy+6#"/>
   </imgdir>
   <imgdir name="2387008">
     <string name="name" value="Qualm Guardian Card"/>
-    <string name="desc" value="A card with a picture of the Qualm Guardian.n#cWhen hunting on the Road of RegretsnJump +6#"/>
+    <string name="desc" value="A card with a picture of the Qualm Guardian.\n#cWhen hunting on the Road of Regrets, Jump+6#"/>
   </imgdir>
   <imgdir name="2387009">
     <string name="name" value="Chief Qualm Guardian Card"/>
-    <string name="desc" value="A card with a picture of the Chief Qualm Guardian.n#cWhen hunting on the Road of RegretsnSpeed +6#"/>
+    <string name="desc" value="A card with a picture of the Chief Qualm Guardian.\n#cWhen hunting on the Road of Regrets, Speed+6#"/>
   </imgdir>
   <imgdir name="2387010">
     <string name="name" value="Oblivion Monk Card"/>
-    <string name="desc" value="A card with a picture of the Oblivion Monk.n#cWhen hunting on the Road to OblivionnEvasion rate +6#"/>
+    <string name="desc" value="A card with a picture of the Oblivion Monk.\n#cWhen hunting on the Road to Oblivion, Evasion rate+6#"/>
   </imgdir>
   <imgdir name="2387011">
     <string name="name" value="Oblivion Monk Trainee Card"/>
-    <string name="desc" value="A card with a picture of the Oblivion Monk Trainee.n#cWhen hunting on the Road to OblivionnAccuracy +6#"/>
+    <string name="desc" value="A card with a picture of the Oblivion Monk Trainee.\n#cWhen hunting on the Road to Oblivion, Accuracy+6#"/>
   </imgdir>
   <imgdir name="2387012">
     <string name="name" value="Oblivion Guardian Card"/>
-    <string name="desc" value="A card with a picture of the Oblivion Guardian.n#cWhen hunting on the Road to OblivionnJump +6#"/>
+    <string name="desc" value="A card with a picture of the Oblivion Guardian.\n#cWhen hunting on the Road to Oblivion, Jump+6#"/>
   </imgdir>
   <imgdir name="2387013">
     <string name="name" value="Chief Oblivion Guardian Card"/>
-    <string name="desc" value="A card with a picture of the Chief Oblivion Guardian.n#cWhen hunting on the Road to OblivionnSpeed +6#"/>
+    <string name="desc" value="A card with a picture of the Chief Oblivion Guardian.\n#cWhen hunting on the Road to Oblivion, Speed+6#"/>
   </imgdir>
   <imgdir name="2388000">
     <string name="name" value="Mano Card"/>
-    <string name="desc" value="A card that features Mano.n#cIf hunting around the area of Lith HarbornItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Mano.\n#cIf hunting around the area of Lith Harbor, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388001">
     <string name="name" value="King Slime Card"/>
-    <string name="desc" value="A card that features King Slime.n#cIf hunting around the area of Kerning CitynSpeed +1/Jump +1"/>
+    <string name="desc" value="A card that features King Slime.\n#cIf hunting around the area of Kerning City, Speed+1/Jump+1"/>
   </imgdir>
   <imgdir name="2388002">
     <string name="name" value="Faust Card"/>
-    <string name="desc" value="A card that features Faust.n#cIf hunting around the area of EllinianItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Faust.\n#cIf hunting around the area of Ellinia, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388003">
     <string name="name" value="King Clang Card"/>
-    <string name="desc" value="A card that features King Clang.n#cIf hunting around the area of Florina BeachnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features King Clang.\n#cIf hunting around the area of Florina Beach, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388004">
     <string name="name" value="Alishar Card"/>
-    <string name="desc" value="A card that features Alishar.n#cIf hunting around the area of Eos TowernItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Alishar.\n#cIf hunting around the area of Eos Tower, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388005">
     <string name="name" value="Timer Card"/>
-    <string name="desc" value="A card that features Timer.n#cIf hunting at the upper floors of the ClocktowernItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Timer.\n#cIf hunting at the upper floors of the Clocktower, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388006">
     <string name="name" value="Mushmom Card"/>
-    <string name="desc" value="A card that features Mushmom.n#cIf hunting around the area of HenesysnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Mushmom.\n#cIf hunting around the area of Henesys, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388007">
     <string name="name" value="Dyle Card"/>
-    <string name="desc" value="A card that features Dyle.n#cIf hunting around the area of Kerning CitynItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Dyle.\n#cIf hunting around the area of Kerning City, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388008">
     <string name="name" value="Zombie Mushmom"/>
-    <string name="desc" value="A card that features Zombie Mushmom.n#cIf hunting around the area of Ant TunnelnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Zombie Mushmom.\n#cIf hunting around the area of Ant Tunnel, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388009">
     <string name="name" value="Nine-Tailed Fox Card"/>
-    <string name="desc" value="A card that features Nine-Tailed Fox.n#cIf hunting around the area of Korean Folk TownnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Nine-Tailed Fox.\n#cIf hunting around the area of Korean Folk Town, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388010">
     <string name="name" value="Tae Roon Card"/>
-    <string name="desc" value="A card that features Tae Roon.n#cIf hunting around the area of Sky ForestnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Tae Roon.\n#cIf hunting around the area of Sky Forest, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388011">
     <string name="name" value="Lord Pirate Card"/>
-    <string name="desc" value="A card that features Lord Pirate.n#cIf hunting around the area of Herb TownnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Lord Pirate.\n#cIf hunting around the area of Herb Town, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388012">
     <string name="name" value="Papa Pixie Card"/>
-    <string name="desc" value="A card that features Papa Pixie.n#cIf hunting around the area of Cloud TownnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Papa Pixie.\n#cIf hunting around the area of Cloud Town, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388013">
     <string name="name" value="King Sage Cat Card"/>
-    <string name="desc" value="A card that features King Sage Cat.n#cIf hunting around the area of Peach FarmnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features King Sage Cat.\n#cIf hunting around the area of Peach Farm, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388014">
     <string name="name" value="Frankenroid Card"/>
-    <string name="desc" value="A card that features Frankenroid.n#cIf hunting around the area of MagatianItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Frankenroid.\n#cIf hunting around the area of Magatia, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388015">
     <string name="name" value="Elliza Card"/>
-    <string name="desc" value="A card that features Elliza.n#cIf hunting around the area of Orbis gardennItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Elliza.\n#cIf hunting around the area of Orbis Garden, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388016">
     <string name="name" value="Snowman Card"/>
-    <string name="desc" value="A card that features Snowman.n#cIf hunting around the area of SnowfieldsnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Snowman.\n#cIf hunting around the area of Snowfields, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388017">
     <string name="name" value="Crimson Balrog Card"/>
-    <string name="desc" value="A card that features Crimson Balrog.n#cIf hunting at El Nath / OrbisnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Crimson Balrog.\n#cIf hunting at El Nath/Orbis, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388018">
     <string name="name" value="Manon Card"/>
-    <string name="desc" value="A card that features Manon.n#cIf hunting at Leafre ForestnMeso drop rate is increased#"/>
+    <string name="desc" value="A card that features Manon.\n#cIf hunting at Leafre Forest, Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388019">
     <string name="name" value="Griffey Card"/>
-    <string name="desc" value="A card that features Griffey.n#cIf hunting at Leafre ForestnItem drop rates are increased#"/>
+    <string name="desc" value="A card that features Griffey.\n#cIf hunting at Leafre Forest, Item drop rates are increased#"/>
   </imgdir>
   <imgdir name="2388020">
     <string name="name" value="Pianus Card"/>
-    <string name="desc" value="A card that features Pianus.n#cIf hunting around the Aqua Road areanItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Pianus.\n#cIf hunting around the Aqua Road area, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388021">
     <string name="name" value="Ergoth Card"/>
-    <string name="desc" value="A card that features Ergoth.n#cWhen party huntingnJump +6/Speed +6#"/>
+    <string name="desc" value="A card that features Ergoth.\n#cWhen party hunting, Jump+6/Speed+6#"/>
   </imgdir>
   <imgdir name="2388022">
     <string name="name" value="Papulatus Card"/>
-    <string name="desc" value="A card that features Papulatus.n#cIf hunting at the lower levels of the ClocktowernItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Papulatus.\n#cIf hunting at the lower levels of the Clocktower, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388023">
     <string name="name" value="Zakum Card"/>
-    <string name="desc" value="A card that features Zakum.n#cIf hunting around the area of the Dead MinenItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Zakum.\n#cIf hunting around the area of the Dead Mine, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388024">
     <string name="name" value="Horned Tail Card"/>
-    <string name="desc" value="A card that features Horned Tail.n#cIf hunting around the area of Minar ForestnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Horned Tail.\n#cIf hunting around the area of Minar Forest, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388025">
     <string name="name" value="Stumpy Card"/>
-    <string name="desc" value="A card that features Stumpyn#cIf hunting around the area of PerionnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Stumpy.\n#cIf hunting around the area of Perion, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388026">
     <string name="name" value="Jr. Balrog Card"/>
-    <string name="desc" value="A card that features Jr. Balrog.n#cIf hunting around the area of SleepywoodnItem/Meso drop rate is increased#"/>
+    <string name="desc" value="A card that features Jr. Balrog.\n#cIf hunting around the area of Sleepywood, Item/Meso drop rate is increased#"/>
   </imgdir>
   <imgdir name="2388027">
     <string name="name" value="Rudolph Card"/>
@@ -5985,59 +5985,59 @@
   </imgdir>
   <imgdir name="2388029">
     <string name="name" value="Deo Card"/>
-    <string name="desc" value="A card that features Deo.n#cIf hunting around the desert areanItem/Meso drop rate will be increased#"/>
+    <string name="desc" value="A card that features Deo.\n#cIf hunting around the desert area, Item/Meso drop rate will be increased#"/>
   </imgdir>
   <imgdir name="2388030">
     <string name="name" value="Seruf Card"/>
-    <string name="desc" value="A card that features Seruf.n#cIf hunting at a shallow seanItem/Meso drop rate will be increased#"/>
+    <string name="desc" value="A card that features Seruf.\n#cIf hunting at a shallow sea, Item/Meso drop rate will be increased#"/>
   </imgdir>
   <imgdir name="2388031">
     <string name="name" value="Zeno Card"/>
-    <string name="desc" value="A card that features Zeno.n#cIf hunting around the area of Omega SectornItem/Meso drop rate will be increased#"/>
+    <string name="desc" value="A card that features Zeno.\n#cIf hunting around the area of Omega Sector, Item/Meso drop rate will be increased#"/>
   </imgdir>
   <imgdir name="2388032">
     <string name="name" value="Kimera Card"/>
-    <string name="desc" value="A card that features Kimera.n#cIf hunting around the lab areanItem/meso drop rate increases#"/>
+    <string name="desc" value="A card that features Kimera.\n#cIf hunting around the lab area, Item/meso drop rate increases#"/>
   </imgdir>
   <imgdir name="2388033">
     <string name="name" value="Leviathan Card"/>
-    <string name="desc" value="A card that features Leviathan.n#cIf hunting around the area of Dragon ForestnItem/Meso drop rate will be increased#"/>
+    <string name="desc" value="A card that features Leviathan.\n#cIf hunting around the area of Dragon Forest, Item/Meso drop rate will be increased#"/>
   </imgdir>
   <imgdir name="2388039">
     <string name="name" value="Poison Golem Card"/>
-    <string name="desc" value="A picture of Poison Golem is on this card.n#cWhile hunting in Ellin ForestnDrop rate of item and meso increase#"/>
+    <string name="desc" value="A picture of Poison Golem is on this card.\n#cWhile hunting in Ellin Forest, Drop rate of item and meso increase#"/>
   </imgdir>
   <imgdir name="2388040">
     <string name="name" value="Dodo Card"/>
-    <string name="desc" value="A card with a picture of Dodo.n#cWhen hunting on Memory LanenItem/Meso Drop rate increase#"/>
+    <string name="desc" value="A card with a picture of Dodo.\n#cWhen hunting on Memory Lane, Item/Meso Drop rate increase#"/>
   </imgdir>
   <imgdir name="2388041">
     <string name="name" value="Lilynouch Card"/>
-    <string name="desc" value="A card with a picture of Lilynouch.n#cWhen hunting on the Road of RegretsnItem/Meso Drop rate increase#"/>
+    <string name="desc" value="A card with a picture of Lilynouch.\n#cWhen hunting on the Road of Regrets, Item/Meso Drop rate increase#"/>
   </imgdir>
   <imgdir name="2388042">
     <string name="name" value="Lyka Card"/>
-    <string name="desc" value="A card with a picture of Lyka.n#cWhen hunting on the Road to OblivionnItem/Meso Drop rate increase#"/>
+    <string name="desc" value="A card with a picture of Lyka.\n#cWhen hunting on the Road to Oblivion, Item/Meso Drop rate increase#"/>
   </imgdir>
   <imgdir name="2388043">
     <string name="name" value="Pink Bean"/>
-    <string name="desc" value="A card with a picture of Pink Bean.n#cWhen hunting at the Temple of TimenItem/Meso Drop rate increase#"/>
+    <string name="desc" value="A card with a picture of Pink Bean.\n#cWhen hunting at the Temple of Time, Item/Meso Drop rate increase#"/>
   </imgdir>
   <imgdir name="2430000">
     <string name="name" value="Torn Cygnus&apos; Book Volume 1"/>
-    <string name="desc" value="When used one at a time, a special power covers my body and blesses me.  I think if I collect 20, I&apos;ll be able to read what&apos;s written inside."/>
+    <string name="desc" value="When used one at a time, a special power covers my body and blesses me. I think if I collect 20, I&apos;ll be able to read what&apos;s written inside."/>
   </imgdir>
   <imgdir name="2430001">
     <string name="name" value="Torn Cygnus&apos; Book Volume 2"/>
-    <string name="desc" value="When used one at a time, a special power covers my body and blesses me.  I think if I collect 20, I&apos;ll be able to read what&apos;s written inside."/>
+    <string name="desc" value="When used one at a time, a special power covers my body and blesses me. I think if I collect 20, I&apos;ll be able to read what&apos;s written inside."/>
   </imgdir>
   <imgdir name="2430002">
     <string name="name" value="Torn Cygnus&apos; Book Volume 3"/>
-    <string name="desc" value="When used one at a time, a special power covers my body and blesses me.  I think if I collect 20, I&apos;ll be able to read what&apos;s written inside."/>
+    <string name="desc" value="When used one at a time, a special power covers my body and blesses me. I think if I collect 20, I&apos;ll be able to read what&apos;s written inside."/>
   </imgdir>
   <imgdir name="2430003">
     <string name="name" value="Cygnus Quiz"/>
-    <string name="desc" value="I can receive a reward by answering questions regarding the Cygnus Knights.  I should click on it and try."/>
+    <string name="desc" value="I can receive a reward by answering questions regarding the Cygnus Knights. I should click on it and try."/>
   </imgdir>
   <imgdir name="2022554">
     <string name="name" value="Independence Day Firecracker 1"/>
@@ -6353,7 +6353,7 @@
   </imgdir>
   <imgdir name="2022428">
     <string name="name" value="Mysterious Box"/>
-    <string name="desc" value="A box with something mysterious inside. I should open it to see what it could be. If it&apos;s my lucky day, I might find an awesome gift inside.n#cYou can open it by double-clicking on it.#"/>
+    <string name="desc" value="A box with something mysterious inside. I should open it to see what it could be. If it&apos;s my lucky day, I might find an awesome gift inside.\n#cYou can open it by double-clicking on it.#"/>
   </imgdir>
   <imgdir name="2022429">
     <string name="name" value="Protective Shield"/>
@@ -6405,7 +6405,7 @@
   </imgdir>
   <imgdir name="2022457">
     <string name="name" value="Power Elixir"/>
-    <string name="desc" value="A legendary potion.nFully recovers HP and MP."/>
+    <string name="desc" value="A legendary potion.\nFully recovers HP and MP."/>
   </imgdir>
   <imgdir name="2022458">
     <string name="name" value="Shinsoo&apos;s Blessing"/>
@@ -6433,23 +6433,23 @@
   </imgdir>
   <imgdir name="2022465">
     <string name="name" value="Heartpounding Box"/>
-    <string name="desc" value="A box in which no one has a clue what&apos;s in it. If the luck in is your side, then a beautiful present might be in store.n#cDouble-click to open.#"/>
+    <string name="desc" value="A box in which no one has a clue what&apos;s in it. If luck is on your side, then a beautiful present might be in store for you.\n#cDouble-click to open.#"/>
   </imgdir>
   <imgdir name="2022466">
     <string name="name" value="Heartpounding Box"/>
-    <string name="desc" value="A box in which no one has a clue what&apos;s in it. If the luck in is your side, then a beautiful present might be in store.n#cDouble-click to open.#"/>
+    <string name="desc" value="A box in which no one has a clue what&apos;s in it. If luck is on your side, then a beautiful present might be in store for you.\n#cDouble-click to open.#"/>
   </imgdir>
   <imgdir name="2022467">
     <string name="name" value="Heartpounding Box"/>
-    <string name="desc" value="A box in which no one has a clue what&apos;s in it. If the luck in is your side, then a beautiful present might be in store.n#cDouble-click to open.#"/>
+    <string name="desc" value="A box in which no one has a clue what&apos;s in it. If luck is on your side, then a beautiful present might be in store for you.\n#cDouble-click to open.#"/>
   </imgdir>
   <imgdir name="2022468">
     <string name="name" value="Heartpounding Box"/>
-    <string name="desc" value="A box in which no one has a clue what&apos;s in it. If the luck in is your side, then a beautiful present might be in store.n#cDouble-click to open.#"/>
+    <string name="desc" value="A box in which no one has a clue what&apos;s in it. If luck is on your side, then a beautiful present might be in store for you.\n#cDouble-click to open.#"/>
   </imgdir>
   <imgdir name="2031002">
     <string name="name" value="Invitation to the Moon"/>
-    <string name="desc" value="An invitation to the moon, sent by the Moon Bunnies. Using this will send you directly to Moon Bunny&apos;s ????."/>
+    <string name="desc" value="An invitation to the moon, sent by the Moon Bunnies. Using this will send you directly to the Moon Bunnies."/>
   </imgdir>
   <imgdir name="2031003">
     <string name="name" value="Invitation to the Nest"/>
@@ -6461,71 +6461,71 @@
   </imgdir>
   <imgdir name="2032000">
     <string name="name" value="Richie Gold&apos;s Strange Lamp"/>
-    <string name="desc" value="An unbelievable lamp made by Richie Gold. Use this, and you&apos;ll be led somewhere in in the maze. No one knows exactly where you&apos;ll be sent, though."/>
+    <string name="desc" value="An unbelievable lamp made by Richie Gold. Use this and you&apos;ll be led somewhere in the maze. No one knows exactly where you&apos;ll be sent, though."/>
   </imgdir>
   <imgdir name="2040110">
     <string name="name" value="Red-Nose STR Bandage 60%"/>
-    <string name="desc" value="Improves STR on Rudolf&apos;s Red Nose.\nSuccess Rate:60%, STR +1"/>
+    <string name="desc" value="Improves STR on Rudolf&apos;s Red Nose.\nSuccess rate:60%, STR+1"/>
   </imgdir>
   <imgdir name="2040111">
     <string name="name" value="Red-Nose DEX Bandage 60%"/>
-    <string name="desc" value="Improves DEX on Rudolf&apos;s Red Nose.\nSuccess Rate:60%, DEX +1"/>
+    <string name="desc" value="Improves DEX on Rudolf&apos;s Red Nose.\nSuccess rate:60%, DEX+1"/>
   </imgdir>
   <imgdir name="2040112">
     <string name="name" value="Red-Nose INT Bandage 60%"/>
-    <string name="desc" value="Improves INT on Rudolf&apos;s Red Nose.\nSuccess Rate:60%, INT +1"/>
+    <string name="desc" value="Improves INT on Rudolf&apos;s Red Nose.\nSuccess rate:60%, INT+1"/>
   </imgdir>
   <imgdir name="2040113">
     <string name="name" value="Red-Nose LUK Bandage 60%"/>
-    <string name="desc" value="Improves LUK on Rudolf&apos;s Red Nose.\nSuccess Rate:60%, LUK +1"/>
+    <string name="desc" value="Improves LUK on Rudolf&apos;s Red Nose.\nSuccess rate:60%, LUK+1"/>
   </imgdir>
   <imgdir name="2040114">
     <string name="name" value="Red-Nose ATT Bandage 60%"/>
-    <string name="desc" value="Improves ATT on Rudolf&apos;s Red Nose.\nSuccess Rate:60%, ATT +1"/>
+    <string name="desc" value="Improves ATT on Rudolf&apos;s Red Nose.\nSuccess rate:60%, ATT+1"/>
   </imgdir>
   <imgdir name="2040115">
     <string name="name" value="Red-Nose Weapon DEF Bandage 60%"/>
-    <string name="desc" value="Improves Weapon DEF on Rudolf&apos;s Red Nose.\nSuccess Rate:60%, Weapon DEF+1"/>
+    <string name="desc" value="Improves weapon def. on Rudolf&apos;s Red Nose.\nSuccess rate:60%, weapon def.+1"/>
   </imgdir>
   <imgdir name="2040116">
     <string name="name" value="Red-Nose MP Bandage 60%"/>
-    <string name="desc" value="Improves MP on Rudolf&apos;s Red Nose.\nSuccess Rate:60%, MP+1"/>
+    <string name="desc" value="Improves MP on Rudolf&apos;s Red Nose.\nSuccess rate:60%, MP+1"/>
   </imgdir>
   <imgdir name="2040117">
     <string name="name" value="Red-Nose Magic DEF Bandage 60%"/>
-    <string name="desc" value="Improves Magic DEF on Rudolf&apos;s Red Nose.\nSuccess Rate:60%, Magic DEF+1"/>
+    <string name="desc" value="Improves magic def. on Rudolf&apos;s Red Nose.\nSuccess rate:60%, magic def.+1"/>
   </imgdir>
   <imgdir name="2040118">
     <string name="name" value="Red-Nose Avoidability Bandage 60%"/>
-    <string name="desc" value="Improves Avoidability on Rudolf&apos;s Red Nose.\nSuccess Rate:60%, Avoidability+1"/>
+    <string name="desc" value="Improves avoidability on Rudolf&apos;s Red Nose.\nSuccess rate:60%, Avoidability+1"/>
   </imgdir>
   <imgdir name="2040119">
     <string name="name" value="Red-Nose Accuracy Bandage 60%"/>
-    <string name="desc" value="Improves Accuracy on Rudolf&apos;s Red Nose.\nSuccess Rate:60%, Accuracy+1"/>
+    <string name="desc" value="Improves accuracy on Rudolf&apos;s Red Nose.\nSuccess rate:60%, Accuracy+1"/>
   </imgdir>
   <imgdir name="2044811">
     <string name="name" value="Scroll for Knuckles for ATT 65%"/>
-    <string name="desc" value="Improves ATT on Knuckles.\nSuccess Rate:65%, Weapon Att+2, STR+1"/>
+    <string name="desc" value="Improves weapon attack on knuckles.\nSuccess rate:65%, weapon attack+2, STR+1"/>
   </imgdir>
   <imgdir name="2044812">
     <string name="name" value="Scroll for Knuckles for ATT 15%"/>
-    <string name="desc" value="Improves ATT on Knuckles.\nSuccess Rate:15%, Weapon Att+5, STR+3, Weapon DEF+1"/>
+    <string name="desc" value="Improves weapon attack on knuckles.\nSuccess rate:15%, weapon attack+5, STR+3, weapon def.+1"/>
   </imgdir>
   <imgdir name="2044813">
     <string name="name" value="Scroll for Knuckles for Accuracy 65%"/>
-    <string name="desc" value="Improves Accuracy on Knuckles.\nSuccess Rate:65%, Accuracy+3, DEX+2, Weapon Att+1"/>
+    <string name="desc" value="Improves accuracy on knuckles.\nSuccess rate:65%, accuracy+3, DEX+2, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044814">
     <string name="name" value="Scroll for Knuckles for Accuracy 15%"/>
-    <string name="desc" value="Improves Accuracy on Knuckles.\nSuccess Rate:15%, Accuracy+5, DEX+3, Weapon Att+3"/>
+    <string name="desc" value="Improves accuracy on knuckles.\nSuccess rate:15%, accuracy+5, DEX+3, weapon attack+3"/>
   </imgdir>
   <imgdir name="2044906">
     <string name="name" value="Scroll for Gun for ATT 65%"/>
-    <string name="desc" value="Improves ATT on guns.\nSuccess Rate:65%, Weapon Att.+2, Accuracy+1"/>
+    <string name="desc" value="Improves weapon attack on guns.\nSuccess rate:65%, weapon attack+2, accuracy+1"/>
   </imgdir>
   <imgdir name="2044907">
     <string name="name" value="Scroll for Gun for ATT 15%"/>
-    <string name="desc" value="Improves ATT on guns.\nSuccess Rate:15%, Weapon Att.+5, Accuracy+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on guns.\nSuccess rate:15%, weapon attack+5, accuracy+3, DEX+1"/>
   </imgdir>
   <imgdir name="2049103">
     <string name="name" value="Beach Sandals Scroll 100%"/>
@@ -6541,7 +6541,7 @@
   </imgdir>
   <imgdir name="2100075">
     <string name="name" value="Mu Lung Dojo Summon Package5_Giant Centepede"/>
-    <string name="desc" value="Summon Giant Centepede"/>
+    <string name="desc" value="Summon Giant Centipede"/>
   </imgdir>
   <imgdir name="2100076">
     <string name="name" value="Mu Lung Dojo Summon Package6_Faust"/>
@@ -6605,7 +6605,7 @@
   </imgdir>
   <imgdir name="2100091">
     <string name="name" value="Mu Lung Dojo Summon Package21_Elliza"/>
-    <string name="desc" value="Summon Eliza"/>
+    <string name="desc" value="Summon Elliza"/>
   </imgdir>
   <imgdir name="2100092">
     <string name="name" value="Mu Lung Dojo Summon Package22_Franken Lloyd"/>
@@ -6681,11 +6681,11 @@
   </imgdir>
   <imgdir name="2100117">
     <string name="name" value="Summon Maze Rash"/>
-    <string name="desc" value="Summons Maze Rash"/>
+    <string name="desc" value="Summons Maze Rash."/>
   </imgdir>
   <imgdir name="2100118">
     <string name="name" value="Dr. Kim&apos;s Anti-Virus Project"/>
-    <string name="desc" value="Eliminates Chief Greys."/>
+    <string name="desc" value="Eliminates Chief Grays."/>
   </imgdir>
   <imgdir name="2100119">
     <string name="name" value="Summons Maze Sand Bunny"/>
@@ -6733,7 +6733,7 @@
   </imgdir>
   <imgdir name="2388046">
     <string name="name" value="Mu Gong Card"/>
-    <string name="desc" value="A card with a drawing of Moo Gong on it.n#cWhen hunting in Mu LungnIncreases Item/Meso drop rate.#"/>
+    <string name="desc" value="A card with a drawing of Moo Gong on it.\n#cWhen hunting in Mu Lung, Increases Item/Meso drop rate.#"/>
   </imgdir>
   <imgdir name="2430004">
     <string name="name" value="Richie Gold&apos;s Random Key Pot"/>
@@ -6777,91 +6777,91 @@
   </imgdir>
   <imgdir name="2041211">
     <string name="name" value="Spiegelmann&apos;s Marble"/>
-    <string name="desc" value="Can only be used on Spiegelmann&apos;s Necklace.\nSuccess Rate: 60%, HP +30, MP +30"/>
+    <string name="desc" value="Can only be used on Spiegelmann&apos;s Necklace.\nSuccess rate:60%, HP+30, MP+30"/>
   </imgdir>
   <imgdir name="2044712">
     <string name="name" value="Scroll for Claw for ATT 100%"/>
-    <string name="desc" value="Improves attack on claw.\nSuccess rate:100%, weapon attack+2, accuracy+3"/>
+    <string name="desc" value="Improves weapon attack on claws.\nSuccess rate:100%, weapon attack+2, accuracy+3"/>
   </imgdir>
   <imgdir name="2044612">
     <string name="name" value="Scroll for Crossbow for ATT 100%"/>
-    <string name="desc" value="Improves attack on crossbow.\nSuccess rate:100%, weapon attack+2, accuracy+3"/>
+    <string name="desc" value="Improves weapon attack on crossbows.\nSuccess rate:100%, weapon attack+2, accuracy+3"/>
   </imgdir>
   <imgdir name="2044512">
     <string name="name" value="Scroll for Bow for ATT 100%"/>
-    <string name="desc" value="Improves attack on bow.\nSuccess rate: 100%, weapon attack+2, accuracy +3"/>
+    <string name="desc" value="Improves weapon attack on bows.\nSuccess rate:100%, weapon attack+2, accuracy+3"/>
   </imgdir>
   <imgdir name="2044417">
     <string name="name" value="Scroll for Pole Arm for ATT 100%"/>
-    <string name="desc" value="Improves attack on pole arm.\nSuccess rate:100%, weapon attack+2, STR+2"/>
+    <string name="desc" value="Improves weapon attack on pole arms.\nSuccess rate:100%, weapon attack+2, STR+2"/>
   </imgdir>
   <imgdir name="2044317">
     <string name="name" value="Scroll for Spear for ATT 100%"/>
-    <string name="desc" value="Improves attack on spear.\nSuccess rate:100%, weapon attack+2, STR+2"/>
+    <string name="desc" value="Improves weapon attack on spears.\nSuccess rate:100%, weapon attack+2, STR+2"/>
   </imgdir>
   <imgdir name="2044217">
     <string name="name" value="Scroll for Two-handed BW for ATT 100%"/>
-    <string name="desc" value="Improves attack on two-handed blunt weapon.\nSuccess rate:100%, weapon attack+2, STR+2"/>
+    <string name="desc" value="Improves weapon attack on two-handed blunt weapons.\nSuccess rate:100%, weapon attack+2, STR+2"/>
   </imgdir>
   <imgdir name="2044117">
     <string name="name" value="Scroll for Two-handed Axe for ATT 100%"/>
-    <string name="desc" value="Improves attack on two-handed axe.\nSuccess rate:100%, weapon attack+2, STR+2"/>
+    <string name="desc" value="Improves weapon attack on two-handed axes.\nSuccess rate:100%, weapon attack+2, STR+2"/>
   </imgdir>
   <imgdir name="2044025">
     <string name="name" value="Scroll for Two-handed Sword for ATT 100%"/>
-    <string name="desc" value="Improves attack on two-handed sword.\nSuccess rate:100%, weapon attack+2, STR+2"/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:100%, weapon attack+2, STR+2"/>
   </imgdir>
   <imgdir name="2043812">
     <string name="name" value="Scroll for Staff for Magic ATT 100%"/>
-    <string name="desc" value="Improves magic on staff.\nSuccess rate:100%, magic attack+2, INT+2"/>
+    <string name="desc" value="Improves magic attack on staffs.\nSuccess rate:100%, magic attack+2, INT+2"/>
   </imgdir>
   <imgdir name="2043712">
     <string name="name" value="Scroll for Wand for Magic ATT 100%"/>
-    <string name="desc" value="Improves magic on wand.\nSuccess rate:100%, magic attack+2, INT+2"/>
+    <string name="desc" value="Improves magic attack on wands.\nSuccess rate:100%, magic attack+2, INT+2"/>
   </imgdir>
   <imgdir name="2043312">
     <string name="name" value="Scroll for Dagger for ATT 100%"/>
-    <string name="desc" value="Improves attack on dagger.\nSuccess rate:100%, weapon attack+2, LUK+2"/>
+    <string name="desc" value="Improves weapon attack on daggers.\nSuccess rate:100%, weapon attack+2, LUK+2"/>
   </imgdir>
   <imgdir name="2043217">
     <string name="name" value="Scroll for One-Handed BW for ATT 100%"/>
-    <string name="desc" value="Improves attack on one-handed blunt weapon.\nSuccess rate:100%, weapon attack+2, STR+2"/>
+    <string name="desc" value="Improves weapon attack on one-handed blunt weapons.\nSuccess rate:100%, weapon attack+2, STR+2"/>
   </imgdir>
   <imgdir name="2043117">
     <string name="name" value="Scroll for One-Handed Axe for ATT 100%"/>
-    <string name="desc" value="Improves attack on one-handed axe.\nSuccess rate:100%, weapon attack+2, STR+2"/>
+    <string name="desc" value="Improves weapon attack on one-handed axes.\nSuccess rate:100%, weapon attack+2, STR+2"/>
   </imgdir>
   <imgdir name="2043023">
     <string name="name" value="Scroll for One-Handed Sword for ATT 100%"/>
-    <string name="desc" value="Improves attack on one-handed sword.\nSuccess rate:100%, weapon attack+2, STR+2"/>
+    <string name="desc" value="Improves weapon attack on one-handed swords.\nSuccess rate:100%, weapon attack+2, STR+2"/>
   </imgdir>
   <imgdir name="2041066">
     <string name="name" value="Scroll for Cape for Magic DEF 100%"/>
-    <string name="desc" value="Improves magic def. on the cape.\nSuccess rate:100%, magic def.+3, weapon def.+2"/>
+    <string name="desc" value="Improves magic def. on capes.\nSuccess rate:100%, magic def.+3, weapon def.+2"/>
   </imgdir>
   <imgdir name="2041067">
     <string name="name" value="Scroll for Cape for Weapon DEF 100%"/>
-    <string name="desc" value="Improves weapon def. on the cape.\nSuccess rate:100%, weapon def.+3, magic def. +2"/>
+    <string name="desc" value="Improves weapon def. on capes.\nSuccess rate:100%, weapon def.+3, magic def.+2"/>
   </imgdir>
   <imgdir name="2040936">
     <string name="name" value="Scroll for Shield for DEF 100%"/>
-    <string name="desc" value="Improves weapon def. on the shield.\nSuccess rate:100%, weapon def.+2, magic def.+3"/>
+    <string name="desc" value="Improves DEF on shields.\nSuccess rate:100%, weapon def.+2, magic def.+3"/>
   </imgdir>
   <imgdir name="2040829">
     <string name="name" value="Scroll for Gloves for DEX 100%"/>
-    <string name="desc" value="Improves dexterity on gloves.\nSuccess rate: 100%, accuracy+2, DEX+2"/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:100%, accuracy+2, DEX+2"/>
   </imgdir>
   <imgdir name="2040830">
     <string name="name" value="Scroll for Gloves for ATT 100%"/>
-    <string name="desc" value="Improves attack on gloves.\nSuccess rate 100%, weapon att. +2"/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:100%, weapon attack+2"/>
   </imgdir>
   <imgdir name="2040740">
     <string name="name" value="Scroll for Shoes for DEX 100%"/>
-    <string name="desc" value="Improves dexterity on shoes.\nSuccess rate:100%, Avoidability +2, Accuracy+3"/>
+    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:100%, avoidability+2, accuracy+3"/>
   </imgdir>
   <imgdir name="2040741">
     <string name="name" value="Scroll for Shoes for Jump 100%"/>
-    <string name="desc" value="Improves jump on shoes.\nSuccess rate: 100%, jump +2, DEX+2"/>
+    <string name="desc" value="Improves jump on shoes.\nSuccess rate:100%, jump+2, DEX+2"/>
   </imgdir>
   <imgdir name="2040742">
     <string name="name" value="Scroll for Shoes for Speed 100%"/>
@@ -6869,31 +6869,31 @@
   </imgdir>
   <imgdir name="2040630">
     <string name="name" value="Scroll for Bottomwear for DEF 100%"/>
-    <string name="desc" value="Improves weapon def. on the bottomwear.\nSuccess rate:100%, weapon def. +2, magic def. +3"/>
+    <string name="desc" value="Improves DEF on bottomwear.\nSuccess rate:100%, weapon def.+2, magic def.+3"/>
   </imgdir>
   <imgdir name="2040538">
     <string name="name" value="Scroll for Overall Armor for DEX 100%"/>
-    <string name="desc" value="Improves dexterity on the overall armor.\nSuccess rate:100%, DEX+2, accuracy+3"/>
+    <string name="desc" value="Improves DEX on overalls.\nSuccess rate:100%, DEX+2, accuracy+3"/>
   </imgdir>
   <imgdir name="2040539">
     <string name="name" value="Scroll for Overall Armor for DEF 100%"/>
-    <string name="desc" value="Improves def. on the overall armor.\nSuccess rate:100%, weapon def.+2, magic def.+3"/>
+    <string name="desc" value="Improves DEF on overalls.\nSuccess rate:100%, weapon def.+2, magic def.+3"/>
   </imgdir>
   <imgdir name="2040430">
     <string name="name" value="Scroll for Topwear for DEF 100%"/>
-    <string name="desc" value="Improves weapon def. on topwear.\nSuccess rate:100%, weapon def.+2, magic def.+3"/>
+    <string name="desc" value="Improves DEF on topwear.\nSuccess rate:100%, weapon def.+2, magic def.+3"/>
   </imgdir>
   <imgdir name="2040334">
     <string name="name" value="Scroll for Earring for INT 100%"/>
-    <string name="desc" value="Improves INT on ear accessory.\nSuccess rate:100%, magic attack +2, INT+2"/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:100%, magic attack+2, INT+2"/>
   </imgdir>
   <imgdir name="2040041">
     <string name="name" value="Scroll for Helmet for DEF 100%"/>
-    <string name="desc" value="Improves helmet def.\nSuccess rate:100%, weapon def.+2, magic def., +3"/>
+    <string name="desc" value="Improves DEF on headwear.\nSuccess rate:100%, weapon def.+2, magic def.+3"/>
   </imgdir>
   <imgdir name="2040042">
     <string name="name" value="Scroll for Helmet for HP 100%"/>
-    <string name="desc" value="Improves MaxHP on hats.\nSuccess rate:100%, MaxHP+15"/>
+    <string name="desc" value="Improves MaxHP on headwear.\nSuccess rate:100%, MaxHP+15"/>
   </imgdir>
   <imgdir name="2101200">
     <string name="name" value="GMEvent_Horntail&apos;s Left Head"/>
@@ -7045,15 +7045,15 @@
   </imgdir>
   <imgdir name="2022531">
     <string name="name" value="Meaning of Clovers"/>
-    <string name="desc" value="The meaning of Clovers in luck.  2X item drops for 1 hour."/>
+    <string name="desc" value="The meaning of Clovers is luck. 2X item drops for 1 hour."/>
   </imgdir>
   <imgdir name="2022536">
     <string name="name" value="Underground Temple&apos;s Seal"/>
-    <string name="desc" value="The Seal&apos;s energy has been placed on the Underground Temple in order to trap the Balrog inside. It restricts the abilites of all living things."/>
+    <string name="desc" value="The Seal&apos;s energy has been placed on the Underground Temple in order to trap the Balrog inside. It restricts the abilities of all living things."/>
   </imgdir>
   <imgdir name="2022537">
     <string name="name" value="Gladius&apos; Strength"/>
-    <string name="desc" value="The abilites of the person wieldng the Hero&apos;s Gladius is amplified under the protection of Tristan. Weapon ATT +30 and Magic ATT +30."/>
+    <string name="desc" value="The abilities of the person wielding the Hero&apos;s Gladius is amplified under the protection of Tristan. Weapon ATT +30 and Magic ATT +30."/>
   </imgdir>
   <imgdir name="2022539">
     <string name="name" value="Cry of a Little Lamb"/>
@@ -7093,7 +7093,7 @@
   </imgdir>
   <imgdir name="2022552">
     <string name="name" value="6th Anniversary Gift Box"/>
-    <string name="desc" value="A gift box celebrating Maple Story&apos;s 6th Anniversary. What could be inside? rn#cCan be opened by double-clicking.#"/>
+    <string name="desc" value="A gift box celebrating Maple Story&apos;s 6th Anniversary. What could be inside?\n#cCan be opened by double-clicking.#"/>
   </imgdir>
   <imgdir name="2022553">
     <string name="name" value="Crackers&apos;s Buff"/>
@@ -7113,255 +7113,255 @@
   </imgdir>
   <imgdir name="2040329">
     <string name="name" value="Scroll for Earring for DEX 10%"/>
-    <string name="desc" value="Improves DEX on earrings. nSuccess rate: 10%, Dex +3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on earrings.\nSuccess rate:10%, DEX+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040330">
     <string name="name" value="Scroll for Earring for INT 10%"/>
-    <string name="desc" value="Improves INT on earrings. nSuccess rate: 10%, Magic ATT +5, INT +3, Magic Defense +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:10%, magic attack+5, INT+3, magic defense+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040331">
     <string name="name" value="Scroll for Earring for LUK 10%"/>
-    <string name="desc" value="Improves LUK on earrings. nSuccess rate: 10%, LUK +3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on earrings.\nSuccess rate:10%, LUK+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040728">
     <string name="name" value="Balrog&apos;s STR Scroll 30%"/>
-    <string name="desc" value="Improves STR on Balrog Leather Shoes. nSuccess rate: 30%, STR +2"/>
+    <string name="desc" value="Improves STR on Balrog Leather Shoes.\nSuccess rate:30%, STR+2"/>
   </imgdir>
   <imgdir name="2040729">
     <string name="name" value="Balrog&apos;s INT Scroll 30%"/>
-    <string name="desc" value="Improves INT on Balrog Leather Shoes. nSuccess rate: 30%, INT +2"/>
+    <string name="desc" value="Improves INT on Balrog Leather Shoes.\nSuccess rate:30%, INT+2"/>
   </imgdir>
   <imgdir name="2040730">
     <string name="name" value="Balrog&apos;s LUK Scroll 30%"/>
-    <string name="desc" value="Improves LUK on Balrog Leather Shoes. nSuccess rate: 30%, LUK +2"/>
+    <string name="desc" value="Improves LUK on Balrog Leather Shoes.\nSuccess rate:30%, LUK+2"/>
   </imgdir>
   <imgdir name="2040731">
     <string name="name" value="Balrog&apos;s DEX Scroll 30%"/>
-    <string name="desc" value="Improves DEX on Balrog Leather Shoes. nSuccess rate: 30%, DEX +2"/>
+    <string name="desc" value="Improves DEX on Balrog Leather Shoes.\nSuccess rate:30%, DEX+2"/>
   </imgdir>
   <imgdir name="2040732">
     <string name="name" value="Balrog&apos;s HP Scroll 30%"/>
-    <string name="desc" value="Improves HP on Balrog Leather Shoes. nSuccess rate: 30%, MaxHP +30"/>
+    <string name="desc" value="Improves HP on Balrog Leather Shoes.\nSuccess rate:30%, MaxHP+30"/>
   </imgdir>
   <imgdir name="2040733">
     <string name="name" value="Balrog&apos;s MP Scroll 30%"/>
-    <string name="desc" value="Improves MP on Balrog Leather Shoess. nSuccess rate: 30%. MaxMP +30"/>
+    <string name="desc" value="Improves MP on Balrog Leather Shoess.\nSuccess rate:30%, MaxMP+30"/>
   </imgdir>
   <imgdir name="2040734">
     <string name="name" value="Balrog&apos;s Speed Scroll 30%"/>
-    <string name="desc" value="Improves Speed on Balrog Leather Shoes. nSuccess rate: 30%, Speed +3"/>
+    <string name="desc" value="Improves speed on Balrog Leather Shoes.\nSuccess rate:30%, speed+3"/>
   </imgdir>
   <imgdir name="2040735">
     <string name="name" value="Balrog&apos;s Jump Scroll 30%"/>
-    <string name="desc" value="Improves Jump on Balrog Leather Shoes. nSuccess rate: 30%, Jump +3"/>
+    <string name="desc" value="Improves jump on Balrog Leather Shoes.\nSuccess rate:30%, jump+3"/>
   </imgdir>
   <imgdir name="2040736">
     <string name="name" value="Balrog&apos;s Accuracy Scroll 30%"/>
-    <string name="desc" value="Improves Accuracty on Balrog Leather Shoes. nSuccess rate: 30%, Accuracy +5"/>
+    <string name="desc" value="Improves accuracy on Balrog Leather Shoes.\nSuccess rate:30%, accuracy+5"/>
   </imgdir>
   <imgdir name="2040737">
     <string name="name" value="Balrog&apos;s Avoidability Scroll 30%"/>
-    <string name="desc" value="Improves Avoidability on Balrog Leather Shoes. nSuccess rate: 30%, Avoidability +5"/>
+    <string name="desc" value="Improves avoidability on Balrog Leather Shoes.\nSuccess rate:30%, avoidability+5"/>
   </imgdir>
   <imgdir name="2040738">
     <string name="name" value="Balrog&apos;s Defense Scroll 30%"/>
-    <string name="desc" value="Improves Defense on Balrog Leather Shoes. nSuccess rate: 30%, Weapons Defense +10, Magic Defense +10"/>
+    <string name="desc" value="Improves DEF on Balrog Leather Shoes.\nSuccess rate:30%, weapon def.+10, magic def.+10"/>
   </imgdir>
   <imgdir name="2040739">
     <string name="name" value="Balrog&apos;s Twilight Scroll 5%"/>
-    <string name="desc" value="Improves the function of Balrog Leather Shoes.\nSuccess rate: 5%, STR +4, INT +4, DEX +4, LUK +4, Speed +4, Jump +4, Avoidability +4, Accuracy +4, Weapons Defense +14, Magic Defense +14, MaxHP +40, MaxMP +40"/>
+    <string name="desc" value="Improves the function of Balrog Leather Shoes.\nSuccess rate:5%, STR+4, INT+4, DEX+4, LUK+4, speed+4, jump+4, avoidability+4, accuracy+4, weapon def.+14, magic def.+14, MaxHP+40, MaxMP+40"/>
   </imgdir>
   <imgdir name="2040826">
     <string name="name" value="Scroll for Gloves for ATT 60%"/>
-    <string name="desc" value="Improves ATT on Gloves.\nSuccess rate: 60%, Weapons ATT +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:60%, weapon attack+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041100">
     <string name="name" value="Scroll for Ring for STR 100%"/>
-    <string name="desc" value="Improves STR on Rings. nSuccess rate: 100%, STR +1"/>
+    <string name="desc" value="Improves STR on rings.\nSuccess rate:100%, STR+1"/>
   </imgdir>
   <imgdir name="2041101">
     <string name="name" value="Scroll for Rings for STR 60%"/>
-    <string name="desc" value="Improves STR on Rings.\nSuccess rate: 60%, STR +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on rings.\nSuccess rate:60%, STR+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041102">
     <string name="name" value="Scroll for Rings for STR 10%"/>
-    <string name="desc" value="Improves STR on Rings.\nSuccess rate: 10%, STR +3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on rings.\nSuccess rate:10%, STR+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041103">
     <string name="name" value="Scroll for Rings for INT 100%"/>
-    <string name="desc" value="Improves INT on Rings. nSuccess rate: 100%, INT +1"/>
+    <string name="desc" value="Improves INT on rings.\nSuccess rate:100%, INT+1"/>
   </imgdir>
   <imgdir name="2041104">
     <string name="name" value="Scroll for Rings for INT 60%"/>
-    <string name="desc" value="Improves INT on Rings.\nSuccess rate: 60%, INT +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on rings.\nSuccess rate:60%, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041105">
     <string name="name" value="Scroll for Rings for INT 10%"/>
-    <string name="desc" value="Improves INT on Rings.\nSuccess rate: 10%, INT +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on rings.\nSuccess rate:10%, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041106">
     <string name="name" value="Scroll for Rings for DEX 100%"/>
-    <string name="desc" value="Improves DEX on Rings. nSuccess rate: 100%, DEX +1"/>
+    <string name="desc" value="Improves DEX on rings.\nSuccess rate:100%, DEX+1"/>
   </imgdir>
   <imgdir name="2041107">
     <string name="name" value="Scroll for Rings for DEX 60%"/>
-    <string name="desc" value="Improves DEX on Rings.\nSuccess rate: 100%, DEX +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on rings.\nSuccess rate:100%, DEX+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041108">
     <string name="name" value="Scroll for Rings for DEX 10%"/>
-    <string name="desc" value="Improves DEX on Rings.\nSuccess rate: 10%, DEX +3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on rings.\nSuccess rate:10%, DEX+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041109">
     <string name="name" value="Scroll for Rings for LUK 100%"/>
-    <string name="desc" value="Improves LUK on Rings. nSuccess rate: 100%, LUK +1"/>
+    <string name="desc" value="Improves LUK on rings.\nSuccess rate:100%, LUK+1"/>
   </imgdir>
   <imgdir name="2041110">
     <string name="name" value="Scroll for Rings for LUK 60%"/>
-    <string name="desc" value="Improves LUK on Rings.\nSuccess rate: 60%, LUK+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on rings.\nSuccess rate:60%, LUK+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041111">
     <string name="name" value="Scroll for Rings for LUK 10%"/>
-    <string name="desc" value="Improves LUK on Rings.\nSuccess rate: 10%, LUK +3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on rings.\nSuccess rate:10%, LUK +3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041112">
     <string name="name" value="Dark Scroll for Rings for STR 70%"/>
-    <string name="desc" value="Improves STR on Rings. nSuccess rate: 70%, STR +2nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves STR on rings.\nSuccess rate:70%, STR+2.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041113">
     <string name="name" value="Dark Scroll for Rings for STR 30%"/>
-    <string name="desc" value="Improves STR on Rings. nSuccess rate: 30%, STR +3nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves STR on rings.\nSuccess rate:30%, STR+3.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041114">
     <string name="name" value="Dark Scroll for Rings for INT 70%"/>
-    <string name="desc" value="Improves INT on Rings.\nSuccess rate: 70%, INT +2nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves INT on rings.\nSuccess rate:70%, INT+2.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041115">
     <string name="name" value="Dark Scroll for Rings for INT 30%"/>
-    <string name="desc" value="Improves INT on Rings.\nSuccess rate: 30%, INT +3nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves INT on rings.\nSuccess rate:30%, INT+3.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041116">
     <string name="name" value="Dark Scroll for Rings for DEX 70%"/>
-    <string name="desc" value="Improves DEX on Rings.\nSuccess rate: 70%, DEX +2nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves DEX on rings.\nSuccess rate:70%, DEX+2.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041117">
     <string name="name" value="Dark Scroll for Rings for DEX 30%"/>
-    <string name="desc" value="Improves DEX on Rings. nSuccess rate: 30%, DEX +3nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves DEX on rings.\nSuccess rate:30%, DEX+3.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041118">
     <string name="name" value="Dark Scroll for Rings for LUK 70%"/>
-    <string name="desc" value="Improves LUK on Rings. nSuccess rate: 70%, LUK +2nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves LUK on rings.\nSuccess rate:70%, LUK+2.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041119">
     <string name="name" value="Dark Scroll for Rings for LUK 30%"/>
-    <string name="desc" value="Improves LUK on Rings. nSuccess rate: 30%, LUK +3nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves LUK on rings.\nSuccess rate:30%, LUK+3.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041300">
     <string name="name" value="Scroll for Belts for STR 100%"/>
-    <string name="desc" value="Improves STR on Belts. nSuccess rate: 100%, STR +1"/>
+    <string name="desc" value="Improves STR on belts.\nSuccess rate:100%, STR+1"/>
   </imgdir>
   <imgdir name="2041301">
     <string name="name" value="Scroll for Belts for STR 60%"/>
-    <string name="desc" value="Improves STR on Belts.\nSuccess rate: 60%, STR +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on belts.\nSuccess rate:60%, STR+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041302">
     <string name="name" value="Scroll for Belts for STR 10%"/>
-    <string name="desc" value="Improves STR on Belts.\nSuccess rate: 10%, STR +3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves STR on belts.\nSuccess rate:10%, STR+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041303">
     <string name="name" value="Scroll for Belts for INT 100%"/>
-    <string name="desc" value="Improves INT on Belts. nSuccess rate: 100%, INT +1"/>
+    <string name="desc" value="Improves INT on belts.\nSuccess rate:100%, INT+1"/>
   </imgdir>
   <imgdir name="2041304">
     <string name="name" value="Scroll for Belts for INT 60%"/>
-    <string name="desc" value="Improves INT on Belts.\nSuccess rate: 60%, INT +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on belts.\nSuccess rate:60%, INT+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041305">
     <string name="name" value="Scroll for Belts for INT 10%"/>
-    <string name="desc" value="Improves INT on Belts.\nSuccess rate: 10%, INT +3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves INT on belts.\nSuccess rate:10%, INT+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041306">
     <string name="name" value="Scroll for Belts for DEX 100%"/>
-    <string name="desc" value="Improves DEX on Belts. nSuccess rate: 100%, DEX +1"/>
+    <string name="desc" value="Improves DEX on belts.\nSuccess rate:100%, DEX+1"/>
   </imgdir>
   <imgdir name="2041307">
     <string name="name" value="Scroll for Belts for DEX 60%"/>
-    <string name="desc" value="Improves DEX on Belts.\nSuccess rate: 60%, DEX +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on belts.\nSuccess rate:60%, DEX+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041308">
     <string name="name" value="Scroll for Belts for DEX 10%"/>
-    <string name="desc" value="Improves DEX on Belts.\nSuccess rate: 10%, DEX +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves DEX on belts.\nSuccess rate:10%, DEX+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041309">
     <string name="name" value="Scroll for Belts for LUK 100%"/>
-    <string name="desc" value="Improves LUK on Belts. nSuccess rate: 100%, LUK +1"/>
+    <string name="desc" value="Improves LUK on belts.\nSuccess rate:100%, LUK+1"/>
   </imgdir>
   <imgdir name="2041310">
     <string name="name" value="Scroll for Belts for LUK 60%"/>
-    <string name="desc" value="Improves LUK on Belts.\nSuccess rate: 60%, LUK +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on belts.\nSuccess rate:60%, LUK+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041311">
     <string name="name" value="Scroll for Belts for LUK 10%"/>
-    <string name="desc" value="Improves LUK on Belts.\nSuccess rate: 10%, LUK +3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves LUK on belts.\nSuccess rate:10%, LUK+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2041312">
     <string name="name" value="Dark Scroll for Belts for STR 70%"/>
-    <string name="desc" value="Improves STR on Belts. nSuccess rate: 70%, STR +2nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves STR on belts.\nSuccess rate:70%, STR+2.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041313">
     <string name="name" value="Dark Scroll for Belts for STR 30%"/>
-    <string name="desc" value="Improves STR on Belts. nSuccess rate: 30%, STR +3nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves STR on belts.\nSuccess rate:30%, STR+3.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041314">
     <string name="name" value="Dark Scroll for Belts for INT 70%"/>
-    <string name="desc" value="Improves INT on Belts. nSuccess rate: 70%, INT +2nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves INT on belts.\nSuccess rate:70%, INT+2.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041315">
     <string name="name" value="Dark Scroll for Belts for INT 30%"/>
-    <string name="desc" value="Improves INT on Belts. nSuccess rate: 30%, INT +3nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves INT on belts.\nSuccess rate:30%, INT+3.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041316">
     <string name="name" value="Dark Scroll for Belts for DEX 70%"/>
-    <string name="desc" value="Improves DEX on Belts. nSuccess rate: 70%, DEX +2nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves DEX on belts.\nSuccess rate:70%, DEX+2.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041317">
     <string name="name" value="Dark Scroll for Belts for DEX 30%"/>
-    <string name="desc" value="Improves DEX on Belts. nSuccess rate: 30%, DEX +3nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves DEX on belts.\nSuccess rate:30%, DEX+3.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041318">
     <string name="name" value="Dark Scroll for Belts for LUK 70%"/>
-    <string name="desc" value="Improves LUK on Belts. nSuccess rate: 70%, LUK +2nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves LUK on belts.\nSuccess rate:70%, LUK+2.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2041319">
     <string name="name" value="Dark Scroll for Belts for LUK 30%"/>
-    <string name="desc" value="Improves LUK on Belts. nSuccess rate: 30%, LUK +3nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves LUK on belts.\nSuccess rate:30%, LUK+3.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2044015">
     <string name="name" value="Scroll for Two-Handed Swords for ATT 10%"/>
-    <string name="desc" value="Improves ATT on Two-Handed Swords. nSuccess rate: 10%, Weapons ATT +5, STR +3, Weapons Defense +1"/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:10%, weapon attack+5, STR+3, weapons def.+1"/>
   </imgdir>
   <imgdir name="2049105">
     <string name="name" value="[6th Anniversary] Dark Scroll for Gloves for ATT 70%"/>
-    <string name="desc" value="Improves ATT on Gloves. nSuccess rate: 70%, Weapons ATT +1nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:70%, weapon attack+1.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2049106">
     <string name="name" value="[6th Anniversary] Dark Scroll for Gloves for ATT 30%"/>
-    <string name="desc" value="Improves ATT on Gloves. nSuccess rate: 30%, Weapons ATT +2nIf unsuccessful, item has an 80% chance of being destroyed."/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:30%, weapon attack+2.\nIf unsuccessful, item has an 80% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2049107">
     <string name="name" value="[6th Anniversary] Dark Scroll for Gloves for STR 70%"/>
-    <string name="desc" value="Improves STR on Gloves. nSuccess rate: 70%, Accuracy +2, STR +1nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves STR on gloves.\nSuccess rate:70%, accuracy+2, STR+1.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2049108">
     <string name="name" value="[6th Anniversary] Dark Scroll for Gloves for LUK 70%"/>
-    <string name="desc" value="Improves LUK on Gloves. nSuccess rate: 70%, Accuracy +2, LUK +1nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves LUK on gloves.\nSuccess rate:70%, accuracy+2, LUK+1.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2049109">
     <string name="name" value="[6th Anniversary] Dark Scroll for Gloves for INT 70%"/>
-    <string name="desc" value="Improves INT on Gloves. nSuccess rate: 70%, Accuracy +2, INT +1nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves INT on gloves.\nSuccess rate:70%, accuracy+2, INT+1.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2049110">
     <string name="name" value="[6th Anniversary] Dark Scroll for Gloves for DEX 70%"/>
-    <string name="desc" value="Improves DEX on Gloves. nSuccess rate: 70%, Accuracy +2, DEX +1nIf unsuccessful, item has a 50% chance of being destroyed."/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:70%, accuracy+2, DEX+1.\nIf unsuccessful, item has a 50% chance of being destroyed."/>
   </imgdir>
   <imgdir name="2100108">
     <string name="name" value="Master of Disguise Summoning Sack"/>
@@ -7425,7 +7425,7 @@
   </imgdir>
   <imgdir name="2100130">
     <string name="name" value="Blue Mushroom Summoning Sack"/>
-    <string name="desc" value="Summons a group of Blue Mushrooms"/>
+    <string name="desc" value="Summons a group of Blue Mushrooms."/>
   </imgdir>
   <imgdir name="2100131">
     <string name="name" value="Tristan&apos;s Balrog Summoning Sack"/>
@@ -7521,23 +7521,23 @@
   </imgdir>
   <imgdir name="2388055">
     <string name="name" value="Balrog Card"/>
-    <string name="desc" value="A card that features a Balrog.ncIncreases the Item/Meso drop rates in the central dungeon of Victoria.#"/>
+    <string name="desc" value="A card that features a Balrog.\n#cIncreases the Item/Meso drop rates in the central dungeon of Victoria.#"/>
   </imgdir>
   <imgdir name="2430006">
     <string name="name" value="Mysterious Piece of Paper"/>
-    <string name="desc" value="It&apos;s full of mysterious scribbles. n#cA quest will begin when you double-click it.#"/>
+    <string name="desc" value="It&apos;s full of mysterious scribbles.\n#cA quest will begin when you double-click it.#"/>
   </imgdir>
   <imgdir name="2430007">
     <string name="name" value="Empty Compass"/>
-    <string name="desc" value="A compass with no markings.  However, it can be turned into a working compass if you have the letters #cN,E, W,S#."/>
+    <string name="desc" value="A compass with no markings. However, it can be turned into a working compass if you have the letters #cN,E,W,S#."/>
   </imgdir>
   <imgdir name="2430008">
     <string name="name" value="Golden Compass"/>
-    <string name="desc" value="A golden compass that reveals the location of Gold Richie&apos;s Treasure Island. n#cBy double-clicking it# you can move to the island."/>
+    <string name="desc" value="A golden compass that reveals the location of Gold Richie&apos;s Treasure Island.\n#cBy double-clicking it# you can move to the island."/>
   </imgdir>
   <imgdir name="2430009">
     <string name="name" value="Pure Perfume"/>
-    <string name="desc" value="A perfume that contains the scent of an inexperienced adventurer. n#cBy double-clicking on it#, that scent is released to confuse monsters."/>
+    <string name="desc" value="A perfume that contains the scent of an inexperienced adventurer.\n#cBy double-clicking on it#, that scent is released to confuse monsters."/>
   </imgdir>
   <imgdir name="2430010">
     <string name="name" value="Mysterious Artifact"/>
@@ -7553,11 +7553,11 @@
   </imgdir>
   <imgdir name="2022476">
     <string name="name" value="Chicken Kapitan"/>
-    <string name="desc" value="A popular Malaysian dish. This mild curry contains chicken pieces with rich coconut milk, onions and spices. \nRecovers 4000 HP."/>
+    <string name="desc" value="A popular Malaysian dish. This mild curry contains chicken pieces with rich coconut milk, onions and spices.\nRecovers 4000 HP."/>
   </imgdir>
   <imgdir name="2022477">
     <string name="name" value="Mee Siam"/>
-    <string name="desc" value="A popular Malaysian dish made up of thin rice noodles. Served with salted soy beans, dried bean curd, boiled egg and tamarind. \nRecovers 4000 MP."/>
+    <string name="desc" value="A popular Malaysian dish made up of thin rice noodles. Served with salted soy beans, dried bean curd, boiled egg and tamarind.\nRecovers 4000 MP."/>
   </imgdir>
   <imgdir name="2022478">
     <string name="name" value="Rojak"/>
@@ -7565,91 +7565,91 @@
   </imgdir>
   <imgdir name="2022479">
     <string name="name" value="Kangkung belacan"/>
-    <string name="desc" value="This spicy vegetable dish is served with KanKung (water spinach) and spicy sambal.nImproves Weapon Attack and Magic Attack +8 for 10 minutes."/>
+    <string name="desc" value="This spicy vegetable dish is served with KanKung (water spinach) and spicy sambal.\nImproves Weapon Attack and Magic Attack +8 for 10 minutes."/>
   </imgdir>
   <imgdir name="2022480">
     <string name="name" value="Kuih"/>
-    <string name="desc" value="These sweet, bite-sized delights are a favorite pastry dish served during parties and just for tea.nImproves Speed +10 for 30 minutes."/>
+    <string name="desc" value="These sweet, bite-sized delights are a favorite pastry dish served during parties and just for tea.\nImproves Speed +10 for 30 minutes."/>
   </imgdir>
   <imgdir name="2044713">
     <string name="name" value="Scroll for Claw for ATT 50%"/>
-    <string name="desc" value="Improves attack on claw.\nSuccess rate:50%, weapon attack+5, LUK+1, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on claws.\nSuccess rate:50%, weapon attack+5, LUK+1, DEX+1"/>
   </imgdir>
   <imgdir name="2044613">
     <string name="name" value="Scroll for Crossbow for ATT 50%"/>
-    <string name="desc" value="Improves attack on crossbow.\nSuccess rate:50%, weapon attack+5, DEX+1, STR+1"/>
+    <string name="desc" value="Improves weapon attack on crossbows.\nSuccess rate:50%, weapon attack+5, DEX+1, STR+1"/>
   </imgdir>
   <imgdir name="2044513">
     <string name="name" value="Scroll for Bow for ATT 50%"/>
-    <string name="desc" value="Improves attack on bow.\nSuccess rate:50%, weapon attack +5, DEX+1, STR+1"/>
+    <string name="desc" value="Improves weapon attack on bows.\nSuccess rate:50%, weapon attack+5, DEX+1, STR+1"/>
   </imgdir>
   <imgdir name="2044420">
     <string name="name" value="Scroll for Pole Arm for ATT 50%"/>
-    <string name="desc" value="Improves attack on pole arm.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on pole arms.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
   </imgdir>
   <imgdir name="2044320">
     <string name="name" value="Scroll for Spear for ATT 50%"/>
-    <string name="desc" value="Improves attack on spear.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on spears.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
   </imgdir>
   <imgdir name="2044220">
     <string name="name" value="Scroll for Two-handed BW for ATT 50%"/>
-    <string name="desc" value="Improves attack on two-handed blunt weapon.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed blunt weapons.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
   </imgdir>
   <imgdir name="2044120">
     <string name="name" value="Scroll for Two-handed Axe for ATT 50%"/>
-    <string name="desc" value="Improves attack on two-handed axe.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed axes.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
   </imgdir>
   <imgdir name="2044028">
     <string name="name" value="Scroll for Two-handed Sword for ATT 50%"/>
-    <string name="desc" value="Improves attack on two-handed sword.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on two-handed swords.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
   </imgdir>
   <imgdir name="2043813">
     <string name="name" value="Scroll for Staff for Magic Att. 50%"/>
-    <string name="desc" value="Improves magic on staff.\nSuccess rate:50%, magic attack+5, INT+3, LUK+1"/>
+    <string name="desc" value="Improves magic attack on staffs.\nSuccess rate:50%, magic attack+5, INT+3, LUK+1"/>
   </imgdir>
   <imgdir name="2043713">
     <string name="name" value="Scroll for Wand for Magic Att. 50%"/>
-    <string name="desc" value="Improves magic on wand.\nSuccess rate:50%, magic attack+5, INT+3, LUK+1"/>
+    <string name="desc" value="Improves magic attack on wands.\nSuccess rate:50%, magic attack+5, INT+3, LUK+1"/>
   </imgdir>
   <imgdir name="2043313">
     <string name="name" value="Scroll for Dagger for ATT 50%"/>
-    <string name="desc" value="Improves attack on dagger.\nSuccess rate: 50%, weapon attack +5, LUK+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on daggers.\nSuccess rate:50%, weapon attack+5, LUK+3, DEX+1"/>
   </imgdir>
   <imgdir name="2043220">
     <string name="name" value="Scroll for One-Handed BW for ATT 50%"/>
-    <string name="desc" value="Improves attack on one-handed blunt weapon.\nSuccess rate: 50%, weapon attack +5, STR+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed blunt weapons.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
   </imgdir>
   <imgdir name="2043120">
     <string name="name" value="Scroll for One-Handed Axe for ATT 50%"/>
-    <string name="desc" value="Improves attack on one-handed axe.\nSuccess rate: 50%, weapon attack +5, STR+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed axes.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
   </imgdir>
   <imgdir name="2043022">
     <string name="name" value="Scroll for One-Handed Sword for ATT 50%"/>
-    <string name="desc" value="Improves attack on one-handed sword.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
+    <string name="desc" value="Improves weapon attack on one-handed swords.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
   </imgdir>
   <imgdir name="2041068">
     <string name="name" value="Scroll for Cape for Magic Def. 50%"/>
-    <string name="desc" value="Improves magic def. on the cape.\nSuccess rate:50%, magic def. +5, weapon def. +4"/>
+    <string name="desc" value="Improves magic def. on capes.\nSuccess rate:50%, magic def.+5, weapon def.+4"/>
   </imgdir>
   <imgdir name="2041069">
     <string name="name" value="Scroll for Cape for Weapon Def. 50%"/>
-    <string name="desc" value="Improves weapon def. on the cape.\nSuccess rate:50%, weapon def. +5, magic def.+4"/>
+    <string name="desc" value="Improves weapon def. on capes.\nSuccess rate:50%, weapon def.+5, magic def.+4"/>
   </imgdir>
   <imgdir name="2040943">
     <string name="name" value="Scroll for Shield for DEF 50%"/>
-    <string name="desc" value="Improves weapon def. on the shield.\nSuccess rate 50%, weapon def.+5, magic def.+4"/>
+    <string name="desc" value="Improves weapon def. on shields.\nSuccess rate:50%, weapon def.+5, magic def.+4"/>
   </imgdir>
   <imgdir name="2040833">
     <string name="name" value="Scroll for Gloves for DEX 50%"/>
-    <string name="desc" value="Improves dexterity on gloves.\nSuccess rate:50%, accuracy+3, DEX+3, avoidability+2"/>
+    <string name="desc" value="Improves DEX on gloves.\nSuccess rate:50%, accuracy+3, DEX+3, avoidability+2"/>
   </imgdir>
   <imgdir name="2040834">
     <string name="name" value="Scroll for Gloves for ATT 50%"/>
-    <string name="desc" value="Improves attack on gloves.\nSuccess rate:50%, weapon att.+3"/>
+    <string name="desc" value="Improves weapon attack on gloves.\nSuccess rate:50%, weapon attack+3"/>
   </imgdir>
   <imgdir name="2040755">
     <string name="name" value="Scroll for Shoes for DEX 50%"/>
-    <string name="desc" value="Improves dexterity on shoes.\nSuccess rate:50%, Avoidability +3, accuracy +3, speed+2"/>
+    <string name="desc" value="Improves DEX on shoes.\nSuccess rate:50%, avoidability+3, accuracy+3, speed+2"/>
   </imgdir>
   <imgdir name="2040756">
     <string name="name" value="Scroll for Shoes for Jump 50%"/>
@@ -7661,31 +7661,31 @@
   </imgdir>
   <imgdir name="2040629">
     <string name="name" value="Scroll for Bottomwear for DEF 50%"/>
-    <string name="desc" value="Improves weapon def. on the bottomwear.\nSuccess rate:50%, weapon def.+5, magic def.+4"/>
+    <string name="desc" value="Improves DEF on bottomwear.\nSuccess rate:50%, weapon def.+5, magic def.+4"/>
   </imgdir>
   <imgdir name="2040542">
     <string name="name" value="Scroll for Overall Armor for DEX 50%"/>
-    <string name="desc" value="Improves dexterity on the overall armor.\nSuccess rate:50%, DEX+5, avoidability+1, speed+1"/>
+    <string name="desc" value="Improves DEX on overalls.\nSuccess rate:50%, DEX+5, avoidability+1, speed+1"/>
   </imgdir>
   <imgdir name="2040543">
     <string name="name" value="Scroll for Overall Armor for DEF 50%"/>
-    <string name="desc" value="Improves def. on the overall armor.\nSuccess rate:50%, wepon def. +5, magic def. +4"/>
+    <string name="desc" value="Improves DEF on overalls.\nSuccess rate:50%, weapon def.+5, magic def.+4"/>
   </imgdir>
   <imgdir name="2040429">
     <string name="name" value="Scroll for Topwear for DEF 50%"/>
-    <string name="desc" value="Improves weapon def. on topwear.\nSuccess rate:50%, weapon def. +5, magic def. +4"/>
+    <string name="desc" value="Improves DEF on topwear.\nSuccess rate:50%, weapon def.+5, magic def.+4"/>
   </imgdir>
   <imgdir name="2040333">
     <string name="name" value="Scroll for Earring for INT 50%"/>
-    <string name="desc" value="Improves INT on ear accessory.\nSuccess rate:50%, magic attack +5, INT+3, magic def. +2"/>
+    <string name="desc" value="Improves INT on earrings.\nSuccess rate:50%, magic attack+5, INT+3, magic def.+2"/>
   </imgdir>
   <imgdir name="2040045">
     <string name="name" value="Scroll for Helmet for DEF 50%"/>
-    <string name="desc" value="Improves helmet def.\nSuccess Rate:50%, weapon def.+5, magic def.+4"/>
+    <string name="desc" value="Improves DEF on headwear.\nSuccess rate:50%, weapon def.+5, magic def.+4"/>
   </imgdir>
   <imgdir name="2040046">
     <string name="name" value="Scroll for Helmet for HP 50%"/>
-    <string name="desc" value="Improves MaxHP on hats.\nSuccess rate:50%, MaxHP+35"/>
+    <string name="desc" value="Improves MaxHP on headwear.\nSuccess rate:50%, MaxHP+35"/>
   </imgdir>
   <imgdir name="2101207">
     <string name="name" value="A Parasite Summoning Sack"/>
@@ -7729,7 +7729,7 @@
   </imgdir>
   <imgdir name="2022626">
     <string name="name" value="Zingy Kabab"/>
-    <string name="desc" value="A suspiciously sharp-tasting Kabab that the Witch has made for you.  Increases Magic ATT And Magic DEF +15 for 15 minutes."/>
+    <string name="desc" value="A suspiciously sharp-tasting Kabab that the Witch has made for you. Increases Magic ATT and Magic DEF +15 for 15 minutes."/>
   </imgdir>
   <imgdir name="2022627">
     <string name="name" value="Swamp Wrap"/>
@@ -7737,7 +7737,7 @@
   </imgdir>
   <imgdir name="2022628">
     <string name="name" value="Rough Leather Steak"/>
-    <string name="desc" value="A rough leather steak that the Witch has carefully grilled for you. Increases Magic ATT And Magic Defense +25 for 15 minutes."/>
+    <string name="desc" value="A rough leather steak that the Witch has carefully grilled for you. Increases Magic ATT and Magic Defense +25 for 15 minutes."/>
   </imgdir>
   <imgdir name="2022629">
     <string name="name" value="Witch&apos;s Special Stew"/>
@@ -7781,15 +7781,15 @@
   </imgdir>
   <imgdir name="2000022">
     <string name="name" value="Special Rien Red Potion"/>
-    <string name="desc" value="A special bottle of potion consisting of herbs that only grow in Rien. \nRecovers HP +100."/>
+    <string name="desc" value="A special bottle of potion consisting of herbs that only grow in Rien.\nRecovers HP +100."/>
   </imgdir>
   <imgdir name="2000023">
     <string name="name" value="Special Rien Blue Potion"/>
-    <string name="desc" value="A special bottle of potion consisting of herbs that only grow in Rien. \nRecovers MP +50."/>
+    <string name="desc" value="A special bottle of potion consisting of herbs that only grow in Rien.\nRecovers MP +50."/>
   </imgdir>
   <imgdir name="2002030">
     <string name="name" value="Angelic Steps"/>
-    <string name="desc" value="Allows one to move fast. \nWill increase your speed for 10 minutes."/>
+    <string name="desc" value="Allows one to move fast.\nWill increase your speed for 10 minutes."/>
   </imgdir>
   <imgdir name="2012005">
     <string name="name" value="Angel Apple"/>
@@ -7909,71 +7909,71 @@
   </imgdir>
   <imgdir name="2043021">
     <string name="name" value="King Pepe&apos;s 60% Scroll for One-handed Sword Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Cutlass.\nSuccess Rate: 60%, Weapon Attack +2, STR +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Cutlass.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043116">
     <string name="name" value="King Pepe&apos;s 60% Scroll for One-handed Axe Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Danker.\nSuccess Rate: 60%, Weapon Attack +2, STR +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Danker.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043216">
     <string name="name" value="King Pepe&apos;s 60% Scroll for One-handed BW Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Heavy Hammer.\nSuccess Rate: 60%, Weapon Attack +2, STR +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Heavy Hammer.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043311">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Dagger Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Gephart.\nSuccess Rate: 60%, Weapon Attack +2, Luck +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Gephart.\nSuccess rate:60%, weapon attack+2, LUK+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043711">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Wand Magic Attacks"/>
-    <string name="desc" value="Improves the Magic Attack strength of King Pepe&apos;s Wizard Wand.\nSuccess Rate: 60%, Magic Attack +2, Intelligence +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the magic attack strength of King Pepe&apos;s Wizard Wand.\nSuccess rate:60%, magic attack+2, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2043811">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Staff Magic Attacks"/>
-    <string name="desc" value="Improves the Magic Attacks strength of King Pepe&apos;s Petal Staff.\nSuccess Rate: 60%, Magic Attack +2, Intelligence +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the magic attack strength of King Pepe&apos;s Petal Staff.\nSuccess rate:60%, magic attack+2, INT+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044024">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Two-handed Sword Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Highlander.\nSuccess Rate: 60%, Weapon Attack +2, Strength +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Highlander.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044116">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Two-handed Axe Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Niam.\nSuccess Rate: 60%, Weapon Attack +2, Strength +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Niam.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044216">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Two-handed BW Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Big Hammer.\nSuccess Rate: 60%, Weapon Attack +2, Strength +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Big Hammer.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044316">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Spear Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Nakamaki.\nSuccess Rate: 60%, Weapon Attack +2, Strength +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Nakamaki.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044416">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Polearm Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Axe Polearm.\nSuccess Rate: 60%, Weapon Attack +2, Strength +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Axe Polearm.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044511">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Bow Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Red Viper.\nSuccess Rate: 60%, Weapon Attack +2, Accuracy +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Red Viper.\nSuccess rate:60%, weapon attack+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044611">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Crossbow Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Eagle Crow.\nSuccess Rate: 60%, Weapon Attack +2, Accuracy +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Eagle Crow.\nSuccess rate:60%, weapon attack+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044711">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Thief Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Dark Guardian.\nSuccess Rate: 60%, Weapon Attack +2, Accuracy +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Dark Guardian.\nSuccess rate:60%, weapon attack+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044816">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Knuckle Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Silver Maden.\nSuccess Rate: 60%, Weapon Attack +2, Strength +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Silver Maden.\nSuccess rate:60%, weapon attack+2, STR+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044909">
     <string name="name" value="King Pepe&apos;s 60% Scroll for Gun Attacks"/>
-    <string name="desc" value="Improves the Attack strength of King Pepe&apos;s Shooting Star.\nSuccess Rate: 60%, Weapon Attack +2, Accuracy +1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves the attack strength of King Pepe&apos;s Shooting Star.\nSuccess rate:60%, weapon attack+2, accuracy+1. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2049112">
     <string name="name" value="King Pepe&apos;s 100% Scroll for Weapons"/>
-    <string name="desc" value="Improves or decreases the effectiveness of King Pepe weapons.\nSuccess Rate: 100%"/>
+    <string name="desc" value="Improves or decreases the effectiveness of King Pepe weapons.\nSuccess rate:100%"/>
   </imgdir>
   <imgdir name="2100160">
     <string name="name" value="Gray Yeti and King Pepe Summoning Bag"/>
@@ -8041,59 +8041,59 @@
   </imgdir>
   <imgdir name="2290126">
     <string name="name" value="[Mastery Book] Overswing"/>
-    <string name="desc" value="With a 70% success rate, raises the Mastery Level of #cOverswing# to 20.\nJob: Aran\nCondition: Min Skill Lv. 5"/>
+    <string name="desc" value="This increases the master level of #cOverswing# to 20 with a 70% chance of success.\nJob: Aran\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290127">
     <string name="name" value="[Mastery Book] Overswing"/>
-    <string name="desc" value="With a 50% success rate, raises the Mastery Level of #cOverswing# to 30.\nJob: Aran\nCondition: Min Skill Lv. 15"/>
+    <string name="desc" value="This increases the master level of #cOverswing# to 30 with a 50% chance of success.\nJob: Aran\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290128">
     <string name="name" value="[Mastery Book] High Mastery"/>
-    <string name="desc" value="With a 70% success rate, raises the Mastery Level of #cHigh Mastery# to 20.\nJob: Aran\nCondition: Min Skill Lv. 5"/>
+    <string name="desc" value="This increases the master level of #cHigh Mastery# to 20 with a 70% chance of success.\nJob: Aran\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290129">
     <string name="name" value="[Mastery Book] High Mastery"/>
-    <string name="desc" value="With a 50% success rate, raises the Mastery Level of #cHigh Mastery# to 30.\nJob: Aran\nCondition: Min Skill Lv. 15"/>
+    <string name="desc" value="This increases the master level of #cHigh Mastery# to 30 with a 50% chance of success.\nJob: Aran\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290130">
     <string name="name" value="[Mastery Book] Freeze Standing"/>
-    <string name="desc" value="With a 70% success rate, raises the Mastery Level of #cFreeze Standing# to 20.\nJob: Aran\nCondition: Min Skill Lv. 5"/>
+    <string name="desc" value="This increases the master level of #cFreeze Standing# to 20 with a 70% chance of success.\nJob: Aran\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290131">
     <string name="name" value="[Mastery Book] Freeze Standing"/>
-    <string name="desc" value="With a 50% success rate, raises the Mastery Level of #cFreeze Standing# to 30.\nJob: Aran\nCondition: Min Skill Lv. 15"/>
+    <string name="desc" value="This increases the master level of #cFreeze Standing# to 30 with a 50% chance of success.\nJob: Aran\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290132">
     <string name="name" value="[Mastery Book] Final Blow"/>
-    <string name="desc" value="With a 70% success rate, raises the Mastery Level of #cFinal Blow# to 20.\nJob: Aran\nCondition: Min Skill Lv. 5"/>
+    <string name="desc" value="This increases the master level of #cFinal Blow# to 20 with a 70% chance of success.\nJob: Aran\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290133">
     <string name="name" value="[Mastery Book] Final Blow"/>
-    <string name="desc" value="With a 50% success rate, raises the Mastery Level of #cFinal Blow# to 30.\nJob: Aran\nCondition: Min Skill Lv. 15"/>
+    <string name="desc" value="This increases the master level of #cFinal Blow# to 30 with a 50% chance of success.\nJob: Aran\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290134">
     <string name="name" value="[Mastery Book] High Defense"/>
-    <string name="desc" value="With a 70% success rate, raises the Mastery Level of #cHigh Defense# to 20.\nJob: Aran\nCondition: Min Skill Lv. 5"/>
+    <string name="desc" value="This increases the master level of #cHigh Defense# to 20 with a 70% chance of success.\nJob: Aran\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290135">
     <string name="name" value="[Mastery Book] High Defense"/>
-    <string name="desc" value="With a 50% success rate, raises the Mastery Level of #cHigh Defense# to 30.\nJob: Aran\nCondition: Min Skill Lv. 15"/>
+    <string name="desc" value="This increases the master level of #cHigh Defense# to 30 with a 50% chance of success.\nJob: Aran\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290136">
     <string name="name" value="[Mastery Book] Combo Tempest"/>
-    <string name="desc" value="With a 70% success rate, raises the Mastery Level of #cCombo Tempest# to 20.\nJob: Aran\nCondition: Min Skill Lv. 5"/>
+    <string name="desc" value="This increases the master level of #cCombo Tempest# to 20 with a 70% chance of success.\nJob: Aran\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290137">
     <string name="name" value="[Mastery Book] Combo Tempest"/>
-    <string name="desc" value="With a 50% success rate, raises the Mastery Level of #cCombo Tempest# to 30.\nJob: Aran\nCondition: Min Skill Lv. 15"/>
+    <string name="desc" value="This increases the master level of #cCombo Tempest# to 30 with a 50% chance of success.\nJob: Aran\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290138">
     <string name="name" value="[Mastery Book] Combo Barrier"/>
-    <string name="desc" value="With a 70% success rate, raises the Mastery Level of #cCombo Barrier# to 20.\nJob: Aran\nCondition: Min Skill Lv. 5"/>
+    <string name="desc" value="This increases the master level of #cCombo Barrier# to 20 with a 70% chance of success.\nJob: Aran\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290139">
     <string name="name" value="[Mastery Book] Combo Barrier"/>
-    <string name="desc" value="With a 50% success rate, raises the Mastery Level of #cCombo Barrier# to 30.\nJob: Aran\nCondition: Min Skill Lv. 15"/>
+    <string name="desc" value="This increases the master level of #cCombo Barrier# to 30 with a 50% chance of success.\nJob: Aran\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2380014">
     <string name="name" value="Dejected Green Mushroom Card"/>
@@ -8129,23 +8129,23 @@
   </imgdir>
   <imgdir name="2382092">
     <string name="name" value="Renegade Spore Card"/>
-    <string name="desc" value="A card featuring Renegade Spores\n#cWhen hunting in the Mushroom Castle: \nAvoidability +1"/>
+    <string name="desc" value="A card featuring Renegade Spores.\n#cWhen hunting in the Mushroom Castle, Avoidability+1"/>
   </imgdir>
   <imgdir name="2382093">
     <string name="name" value="Poison Mushroom Card"/>
-    <string name="desc" value="A card featuring the Poison Mushroom\n#cWhen hunting in the Mushroom Castle: \nAccuracy +1"/>
+    <string name="desc" value="A card featuring the Poison Mushroom.\n#cWhen hunting in the Mushroom Castle, Accuracy+1"/>
   </imgdir>
   <imgdir name="2382094">
     <string name="name" value="Intoxicated Pig Card"/>
-    <string name="desc" value="A card featuring the Intoxicated Pig\n#cWhen hunting in the Mushroom Castle: \nSpeed +1"/>
+    <string name="desc" value="A card featuring the Intoxicated Pig.\n#cWhen hunting in the Mushroom Castle, Speed+1"/>
   </imgdir>
   <imgdir name="2382095">
     <string name="name" value="Helmet Pepe Card"/>
-    <string name="desc" value="A card featuring Helmet Pepe\n#cWhen hunting in the Mushroom Castle: \nJump +1"/>
+    <string name="desc" value="A card featuring Helmet Pepe.\n#cWhen hunting in the Mushroom Castle, Jump+1"/>
   </imgdir>
   <imgdir name="2382096">
     <string name="name" value="Royal Guard Pepe Card"/>
-    <string name="desc" value="A card featuring Royal Guard Pepe\n#cWhen hunting in the Mushroom Castle: \nSpeed +1"/>
+    <string name="desc" value="A card featuring Royal Guard Pepe.\n#cWhen hunting in the Mushroom Castle, Speed+1"/>
   </imgdir>
   <imgdir name="2388052">
     <string name="name" value="Giant Centipede Card"/>
@@ -8197,35 +8197,35 @@
   </imgdir>
   <imgdir name="2040758">
     <string name="name" value="Scroll for Shoes for ATT"/>
-    <string name="desc" value="Improves attack on shoes.\nSuccess rate: 100%. Weapon Attack +1"/>
+    <string name="desc" value="Improves weapon attack on shoes.\nSuccess rate:100%, weapon attack+1"/>
   </imgdir>
   <imgdir name="2040759">
     <string name="name" value="Scroll for Shoes for ATT"/>
-    <string name="desc" value="Improves attack on shoes.\nSuccess rate: 60%. Weapon Attack +2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on shoes.\nSuccess rate:60%, weapon attack+2. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2040760">
     <string name="name" value="Scroll for Shoes for ATT"/>
-    <string name="desc" value="Improves attack on shoes.\nSuccess rate: 10%, Weapon Attack +3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
+    <string name="desc" value="Improves weapon attack on shoes.\nSuccess rate:10%, weapon attack+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2044815">
     <string name="name" value="Scroll for Knuckler for Attack 100%"/>
-    <string name="desc" value="Improves attack on Knucklers.\nSuccess rate: 100%. Weapon Attack +2, STR +1"/>
+    <string name="desc" value="Improves weapon attack on knuckles.\nSuccess rate:100%, weapon attack+2, STR+1"/>
   </imgdir>
   <imgdir name="2044817">
     <string name="name" value="Scroll for Knuckler for Attack 50%"/>
-    <string name="desc" value="Improves attack on Knucklers.\nSuccess rate: 50%. Weapon Attack +5, STR +3,  DEX +1"/>
+    <string name="desc" value="Improves weapon attack on knuckles.\nSuccess rate:50%, weapon attack+5, STR+3, DEX+1"/>
   </imgdir>
   <imgdir name="2044908">
     <string name="name" value="Scroll for Gun for Attack 100%"/>
-    <string name="desc" value="Improves attack on Guns.\nSuccess rate: 100%. Weapon Attack +2, Accuracy +1"/>
+    <string name="desc" value="Improves weapon attack on guns.\nSuccess rate:100%, weapon attack+2, accuracy+1"/>
   </imgdir>
   <imgdir name="2044910">
     <string name="name" value="Scroll for Gun for Attack 50%"/>
-    <string name="desc" value="Improves attack on Guns.\nSuccess rate: 50%. Weapon Attack +5, LUK +1, DEX +1"/>
+    <string name="desc" value="Improves weapon attack on guns.\nSuccess rate:50%, weapon attack+5, LUK+1, DEX+1"/>
   </imgdir>
   <imgdir name="2022544">
     <string name="name" value="White Elixir"/>
-    <string name="desc" value="A legendary potion. \nRecovers 50% HP and MP and cancels abnormal statuses. It can recover all abnormal statuses."/>
+    <string name="desc" value="A legendary potion.\nRecovers 50% HP and MP and cancels abnormal statuses. It can recover all abnormal statuses."/>
   </imgdir>
   <imgdir name="2022545">
     <string name="name" value="Dynamite Drink EX"/>
@@ -8241,7 +8241,7 @@
   </imgdir>
   <imgdir name="2430030">
     <string name="name" value="Golden Compass"/>
-    <string name="desc" value="A golden compass that will lead you to Goldrich&apos;s Treasure Island. \n#cDouble-click it to# be transported to the Treasure Island."/>
+    <string name="desc" value="A golden compass that will lead you to Goldrich&apos;s Treasure Island.\n#cDouble-click it to# be transported to the Treasure Island."/>
   </imgdir>
   <imgdir name="2430029">
     <string name="name" value="Mystery Box "/>
@@ -8293,235 +8293,235 @@
   </imgdir>
   <imgdir name="2049200">
     <string name="name" value="Dark Scroll for Accessory for STR 70%  "/>
-    <string name="desc" value="Improves STR on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 70%, STR+2\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves STR on accessories (pendants, belts, rings).\nSuccess rate:70%, STR+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049201">
     <string name="name" value="Dark Scroll for Accessory for STR 30%"/>
-    <string name="desc" value="Improves STR on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 30%, STR+3\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves STR on accessories (pendants, belts, rings).\nSuccess rate:30%, STR+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049202">
     <string name="name" value="Dark Scroll for Accessory for DEX 70%"/>
-    <string name="desc" value="Improves DEX on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 70%, DEX+2\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on accessories (pendants, belts, rings).\nSuccess rate:70%, DEX+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049203">
     <string name="name" value="Dark Scroll for Accessory for DEX 30%"/>
-    <string name="desc" value="Improves DEX on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 30%, DEX+3\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves DEX on accessories (pendants, belts, rings).\nSuccess rate:30%, DEX+3\.nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049204">
     <string name="name" value="Dark Scroll for Accessory for INT 70%"/>
-    <string name="desc" value="Improves INT on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 70%. INT+2\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves INT on accessories (pendants, belts, rings).\nSuccess rate:70%, INT+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049205">
     <string name="name" value="Dark Scroll for Accessory for INT 30%"/>
-    <string name="desc" value="Improves INT on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 30%. INT+3\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves INT on accessories (pendants, belts, rings).\nSuccess rate:30%, INT+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049206">
     <string name="name" value="Dark Scroll for Accessory for LUK 70%"/>
-    <string name="desc" value="Improves LUK on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 70%, LUK+2\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on accessories (pendants, belts, rings).\nSuccess rate:70%, LUK+2.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049207">
     <string name="name" value="Dark Scroll for Accessory for LUK 30%"/>
-    <string name="desc" value="Improves LUK on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 30%, LUK+3\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves LUK on accessories (pendants, belts, rings).\nSuccess rate:30%, LUK+3.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049208">
     <string name="name" value="Dark Scroll for Accessory for HP 70%"/>
-    <string name="desc" value="Improves MaxHP on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 70%, MaxHP+10\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on accessories (pendants, belts, rings).\nSuccess rate:70%, MaxHP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049209">
     <string name="name" value="Dark Scroll for Accessory for HP 30%"/>
-    <string name="desc" value="Improves MaxHP on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 30%, MaxHP+30\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxHP on accessories (pendants, belts, rings).\nSuccess rate:30%, MaxHP+30.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049210">
     <string name="name" value="Dark Scroll for Accessory for MP 70%"/>
-    <string name="desc" value="Improves MaxMP on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 70%, MaxMP+10\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxMP on accessories (pendants, belts, rings).\nSuccess rate:70%, MaxMP+10.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2049211">
     <string name="name" value="Dark Scroll for Accessory for MP 30%"/>
-    <string name="desc" value="Improves MaxMP on Accessories (Pendants, Belts, Rings).\nSuccess Rate: 30%, MaxMP+30\nIf failed, the item will be destroyed at a 50% rate."/>
+    <string name="desc" value="Improves MaxMP on accessories (pendants, belts, rings).\nSuccess rate:30%, MaxMP+30.\nIf failed, the item will be destroyed at a 50% rate."/>
   </imgdir>
   <imgdir name="2044418">
     <string name="name" value="Scroll for Polearm for Accuracy 65%"/>
-    <string name="desc" value="Improves Accuracy on Polearms.\nSuccess Rate: 65%, Accuracy+3, DEX+2, Weapon Attack+1"/>
+    <string name="desc" value="Improves accuracy on pole arms.\nSuccess rate:65%, accuracy+3, DEX+2, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044419">
     <string name="name" value="Scroll for Polearm for Accuracy 15%"/>
-    <string name="desc" value="Improves Accuracy on Polearms.\nSuccess Rate: 15%, Accuracy+5, DEX+3, Weapon Attack+3"/>
+    <string name="desc" value="Improves accuracy on pole arms.\nSuccess rate:15%, accuracy+5, DEX+3, weapon attack+3"/>
   </imgdir>
   <imgdir name="2044318">
     <string name="name" value="Scroll for Spears for Accuracy 65%"/>
-    <string name="desc" value="Improves Accuracy on Spears.\nSuccess Rate: 65%, Accuracy+3, DEX+2, Weapon Attack+1"/>
+    <string name="desc" value="Improves accuracy on spears.\nSuccess rate:65%, accuracy+3, DEX+2, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044319">
     <string name="name" value="Scroll for Spears for Accuracy 15%"/>
-    <string name="desc" value="Improves Accuracy on Spears.\nSuccess Rate: 15%, Accuracy+5, DEX+3, Weapon Attack+3"/>
+    <string name="desc" value="Improves accuracy on spears.\nSuccess rate:15%, accuracy+5, DEX+3, weapon attack+3"/>
   </imgdir>
   <imgdir name="2044218">
     <string name="name" value="Scroll for Two-Handed BW for Accuracy 65%"/>
-    <string name="desc" value="Improves Accuracy on Two-Handed Blunt Weapons.\nSuccess Rate: 65%, Accuracy+3, DEX+2, Weapon Attack+1"/>
+    <string name="desc" value="Improves accuracy on two-handed blunt weapons.\nSuccess rate:65%, accuracy+3, DEX+2, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044219">
     <string name="name" value="Scroll for Two-Handed BW for Accuracy 15%"/>
-    <string name="desc" value="Improves Accuracy on Two-Handed Blunt Weapons.\nSuccess Rate: 15%, Accuracy+5, DEX+3, Weapon Attack+3"/>
+    <string name="desc" value="Improves accuracy on two-handed blunt weapons.\nSuccess rate:15%, accuracy+5, DEX+3, weapon attack+3"/>
   </imgdir>
   <imgdir name="2044118">
     <string name="name" value="Scroll for Two-Handed Axe for Accuracy 65%"/>
-    <string name="desc" value="Improves Accuracy on Two-Handed Axe.\nSuccess Rate: 65%, Accuracy+3, DEX+2, Weapon Attack+1"/>
+    <string name="desc" value="Improves accuracy on two-handed axes.\nSuccess rate:65%, accuracy+3, DEX+2, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044119">
     <string name="name" value="Scroll for Two-Handed Axe for Accuracy 15%"/>
-    <string name="desc" value="Improves Accuracy on Two-Handed Axe.\nSuccess Rate: 15%, Accuracy+5, DEX+3, Weapon Attack+3"/>
+    <string name="desc" value="Improves accuracy on two-handed axex.\nSuccess rate:15%, accuracy+5, DEX+3, weapon attack+3"/>
   </imgdir>
   <imgdir name="2044026">
     <string name="name" value="Scroll for Two-Handed Sword for Accuracy 65%"/>
-    <string name="desc" value="Improves Accuracy on Two-Handed Swords.\nSuccess Rate: 65%, Accuracy+3, DEX+2, Weapon Attack+1"/>
+    <string name="desc" value="Improves accuracy on two-handed swords.\nSuccess rate:65%, accuracy+3, DEX+2, weapon attack+1"/>
   </imgdir>
   <imgdir name="2044027">
     <string name="name" value="Scroll for Two-Handed Sword for Accuracy 15%"/>
-    <string name="desc" value="Improves Accuracy on Two-Handed Swords.\nSuccess Rate: 15%, Accuracy+5, DEX+3, Weapon Attack+3"/>
+    <string name="desc" value="Improves accuracy on two-handed swords.\nSuccess rate:15%, accuracy+5, DEX+3, weapon attack+3"/>
   </imgdir>
   <imgdir name="2043218">
     <string name="name" value="Scroll for One-Handed BW for Accuracy 65%"/>
-    <string name="desc" value="Improves Accuracy on One-Handed Blunt Weapons.\nSuccess Rate: 65%, Accuracy+3, DEX+2, Weapon Attack+1"/>
+    <string name="desc" value="Improves accuracy on one-handed blunt weapons.\nSuccess rate:65%, accuracy+3, DEX+2, weapon attack+1"/>
   </imgdir>
   <imgdir name="2043219">
     <string name="name" value="Scroll for One-Handed BW for Accuracy 15%"/>
-    <string name="desc" value="Improves Accuracy on One-Handed Blunt Weapons.\nSuccess Rate: 15%, Accuracy+5, DEX+3, Weapon Attack+3"/>
+    <string name="desc" value="Improves accuracy on one-handed blunt weapons.\nSuccess rate:15%, accuracy+5, DEX+3, weapon attack+3"/>
   </imgdir>
   <imgdir name="2043118">
     <string name="name" value="Scroll for One-Handed Axe for Accuracy 65%"/>
-    <string name="desc" value="Improves Accuracy on One-Handed Axe.\nSuccess Rate: 65%, Accuracy+3, DEX+2, Weapon Attack+1"/>
+    <string name="desc" value="Improves accuracy on one-handed axes.\nSuccess rate:65%, accuracy+3, DEX+2, weapon attack+1"/>
   </imgdir>
   <imgdir name="2043119">
     <string name="name" value="Scroll for One-Handed Axe for Accuracy 15%"/>
-    <string name="desc" value="Improves Accuracy on One-Handed Axe.\nSuccess Rate: 15%, Accuracy+5, DEX+3, Weapon Attack+3"/>
+    <string name="desc" value="Improves accuracy on one-handed axes.\nSuccess rate:15%, accuracy+5, DEX+3, weapon attack+3"/>
   </imgdir>
   <imgdir name="2043024">
     <string name="name" value="Scroll for One-Handed Sword for Accuracy 65%"/>
-    <string name="desc" value="Improves Accuracy on One-Handed Swords.\nSuccess Rate: 65%, Accuracy+3, DEX+2, Weapon Attack+1"/>
+    <string name="desc" value="Improves accuracy on one-handed swords.\nSuccess rate:65%, accuracy+3, DEX+2, weapon attack+1"/>
   </imgdir>
   <imgdir name="2043025">
     <string name="name" value="Scroll for One-Handed Sword for Accuracy 15%"/>
-    <string name="desc" value="Improves Accuracy on One-Handed Swords.\nSuccess Rate: 15%, Accuracy+5, DEX+3, Weapon Attack+3"/>
+    <string name="desc" value="Improves accuracy on one-handed swords.\nSuccess rate:15%, accuracy+5, DEX+3, weapon attack+3"/>
   </imgdir>
   <imgdir name="2040937">
     <string name="name" value="Scroll for Shield for LUK 65%"/>
-    <string name="desc" value="Improves LUK on Shields.\nSuccess Rate: 65%, LUK+2"/>
+    <string name="desc" value="Improves LUK on shields.\nSuccess rate:65%, LUK+2"/>
   </imgdir>
   <imgdir name="2040938">
     <string name="name" value="Scroll for Shield for LUK 15%"/>
-    <string name="desc" value="Improves LUK on Shields.\nSuccess Rate: 15%, LUK+3"/>
+    <string name="desc" value="Improves LUK on shields.\nSuccess rate:15%, LUK+3"/>
   </imgdir>
   <imgdir name="2040939">
     <string name="name" value="Scroll for Shield for HP 65%"/>
-    <string name="desc" value="Improves HP on Shields.\nSuccess Rate: 65%, MaxHP+15"/>
+    <string name="desc" value="Improves MaxHP on shields.\nSuccess rate:65%, MaxHP+15"/>
   </imgdir>
   <imgdir name="2040940">
     <string name="name" value="Scroll for Shield for HP 15%"/>
-    <string name="desc" value="Improves HP on Shields.\nSuccess Rate: 15%, MaxHP+30"/>
+    <string name="desc" value="Improves MaxHP on shields.\nSuccess rate:15%, MaxHP+30"/>
   </imgdir>
   <imgdir name="2040941">
     <string name="name" value="Scroll for Shield for STR 65%"/>
-    <string name="desc" value="Improves STR on Shields.\nSuccess Rate: 65%, STR+2"/>
+    <string name="desc" value="Improves STR on shields.\nSuccess rate:65%, STR+2"/>
   </imgdir>
   <imgdir name="2040942">
     <string name="name" value="Scroll for Shield for STR 15%"/>
-    <string name="desc" value="Improves STR on Shields.\nSuccess Rate: 15%, STR+3"/>
+    <string name="desc" value="Improves STR on shields.\nSuccess rate:15%, STR+3"/>
   </imgdir>
   <imgdir name="2040831">
     <string name="name" value="Scroll for Gloves for HP 65%"/>
-    <string name="desc" value="Improves HP on Gloves.\nSuccess Rate: 65%, MaxHP+15"/>
+    <string name="desc" value="Improves MaxHP on gloves.\nSuccess rate:65%, MaxHP+15"/>
   </imgdir>
   <imgdir name="2040832">
     <string name="name" value="Scroll for Gloves for HP 15%"/>
-    <string name="desc" value="Improves HP on Gloves.\nSuccess Rate: 15%, MaxHP+30"/>
+    <string name="desc" value="Improves MaxHP on gloves.\nSuccess rate:15%, MaxHP+30"/>
   </imgdir>
   <imgdir name="2040631">
     <string name="name" value="Scroll for Bottomwear for Jump 65%"/>
-    <string name="desc" value="Improves Jump on Bottomwear.\nSuccess Rate: 65%, Jump+2, Avoidability+1"/>
+    <string name="desc" value="Improves jump on bottomwear.\nSuccess rate:65%, jump+2, avoidability+1"/>
   </imgdir>
   <imgdir name="2040632">
     <string name="name" value="Scroll for Bottomwear for Jump 15%"/>
-    <string name="desc" value="Improves Jump on Bottomwear.\nSuccess Rate: 15%, Jump+4, Avoidability+2"/>
+    <string name="desc" value="Improves jump on bottomwear.\nSuccess rate:15%, jump+4, avoidability+2"/>
   </imgdir>
   <imgdir name="2040633">
     <string name="name" value="Scroll for Bottomwear for HP 65%"/>
-    <string name="desc" value="Improves HP on Bottomwear.\nSuccess Rate: 65%, MaxHP+15"/>
+    <string name="desc" value="Improves HP on bottomwear.\nSuccess rate:65%, MaxHP+15"/>
   </imgdir>
   <imgdir name="2040634">
     <string name="name" value="Scroll for Bottomwear for HP 15%"/>
-    <string name="desc" value="Improves HP on Bottomwear.\nSuccess Rate: 15%, MaxHP+30"/>
+    <string name="desc" value="Improves HP on bottomwear.\nSuccess rate:15%, MaxHP+30"/>
   </imgdir>
   <imgdir name="2040635">
     <string name="name" value="Scroll for Bottomwear for DEX 65%"/>
-    <string name="desc" value="Improves DEX on Bottomwear.\nSuccess Rate: 65%, DEX+2, Accuracy+1"/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:65%, DEX+2, accuracy+1"/>
   </imgdir>
   <imgdir name="2040636">
     <string name="name" value="Scroll for Bottomwear for DEX 15%"/>
-    <string name="desc" value="Improves DEX on Bottomwear.\nSuccess Rate: 15%, DEX+3, Accuracy+2, Speed+1"/>
+    <string name="desc" value="Improves DEX on bottomwear.\nSuccess rate:15%, DEX+3, accuracy+2, speed+1"/>
   </imgdir>
   <imgdir name="2040540">
     <string name="name" value="Scroll for Overall Armor for STR 65%"/>
-    <string name="desc" value="Improves STR on Overall Armor.\nSuccess Rate: 65%, STR+2, Weapon Attack+1"/>
+    <string name="desc" value="Improves STR on overalls.\nSuccess rate:65%, STR+2, weapon attack+1"/>
   </imgdir>
   <imgdir name="2040541">
     <string name="name" value="Scroll for Overall Armor for STR 15%"/>
-    <string name="desc" value="Improves STR on Overall Armor.\nSuccess Rate: 15%, STR+5, Weapon Attack+3, MaxHP+5"/>
+    <string name="desc" value="Improves STR on overalls.\nSuccess rate:15%, STR+5, weapon attack+3, MaxHP+5"/>
   </imgdir>
   <imgdir name="2040431">
     <string name="name" value="Scroll for Topwear for STR 65%"/>
-    <string name="desc" value="Improves STR on Topwear.\nSuccess Rate 65%, STR+2"/>
+    <string name="desc" value="Improves STR on topwear.\nSuccess rate:65%, STR+2"/>
   </imgdir>
   <imgdir name="2040432">
     <string name="name" value="Scroll for Topwear for STR 15%"/>
-    <string name="desc" value="Improves STR on Topwear.\nSuccess Rate 15%, STR+3"/>
+    <string name="desc" value="Improves STR on topwear.\nSuccess rate:15%, STR+3"/>
   </imgdir>
   <imgdir name="2040433">
     <string name="name" value="Scroll for Topwear for HP 65%"/>
-    <string name="desc" value="Improves HP on Topwear.\nSuccess Rate 65%, MaxHP + 15"/>
+    <string name="desc" value="Improves HP on topwear.\nSuccess rate:65%, MaxHP+15"/>
   </imgdir>
   <imgdir name="2040434">
     <string name="name" value="Scroll for Topwear for HP 15%"/>
-    <string name="desc" value="Improves HP on Topwear.\nSuccess Rate 15%, MaxHP + 30"/>
+    <string name="desc" value="Improves HP on topwear.\nSuccess rate:15%, MaxHP+30"/>
   </imgdir>
   <imgdir name="2040435">
     <string name="name" value="Scroll for Topwear for LUK 65%"/>
-    <string name="desc" value="Improves LUK on Topwear.\nSuccess Rate: 65%, LUK+2"/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:65%, LUK+2"/>
   </imgdir>
   <imgdir name="2040436">
     <string name="name" value="Scroll for Topwear for LUK 15%"/>
-    <string name="desc" value="Improves LUK on Topwear.\nSuccess Rate: 15%, LUK+3"/>
+    <string name="desc" value="Improves LUK on topwear.\nSuccess rate:15%, LUK+3"/>
   </imgdir>
   <imgdir name="2040335">
     <string name="name" value="Scroll for Earring for DEX 65%"/>
-    <string name="desc" value="Improves DEX on Earrings.\nSuccess Rate: 65%, DEX+2"/>
+    <string name="desc" value="Improves DEX on earrings.\nSuccess rate:65%, DEX+2"/>
   </imgdir>
   <imgdir name="2040336">
     <string name="name" value="Scroll for Earring for DEX 15%"/>
-    <string name="desc" value="Improves DEX on Earrings.\nSuccess Rate: 15%, DEX+3"/>
+    <string name="desc" value="Improves DEX on earrings.\nSuccess rate:15%, DEX+3"/>
   </imgdir>
   <imgdir name="2040337">
     <string name="name" value="Scroll for Earring for LUK 65%"/>
-    <string name="desc" value="Improves LUK on Earrings.\nSuccess Rate: 65%, LUK+2"/>
+    <string name="desc" value="Improves LUK on earrings.\nSuccess rate:65%, LUK+2"/>
   </imgdir>
   <imgdir name="2040338">
     <string name="name" value="Scroll for Earring for LUK 15%"/>
-    <string name="desc" value="Improves LUK on Earrings.\nSuccess Rate: 15%, LUK+3"/>
+    <string name="desc" value="Improves LUK on earrings.\nSuccess rate:15%, LUK+3"/>
   </imgdir>
   <imgdir name="2040339">
     <string name="name" value="Scroll for Earring for HP 65%"/>
-    <string name="desc" value="Improves HP on Earrings.\nSuccess Rate: 65%, MaxHP+15"/>
+    <string name="desc" value="Improves HP on earrings.\nSuccess rate:65%, MaxHP+15"/>
   </imgdir>
   <imgdir name="2040340">
     <string name="name" value="Scroll for Earring for HP 15%"/>
-    <string name="desc" value="Improves HP on Earrings.\nSuccess Rate: 15%, MaxHP+30"/>
+    <string name="desc" value="Improves HP on earrings.\nSuccess rate:15%, MaxHP+30"/>
   </imgdir>
   <imgdir name="2040043">
     <string name="name" value="Scroll for Helmet for DEX 65%"/>
-    <string name="desc" value="Improves DEX on Helmets.\nSuccess Rate 65%, DEX+2"/>
+    <string name="desc" value="Improves DEX on headwear.\nSuccess rate:65%, DEX+2"/>
   </imgdir>
   <imgdir name="2040044">
     <string name="name" value="Scroll for Helmet for DEX 15%"/>
-    <string name="desc" value="Improves DEX on Helmets.\nSuccess Rate 15%, DEX+3"/>
+    <string name="desc" value="Improves DEX on headwear.\nSuccess rate:15%, DEX+3"/>
   </imgdir>
   <imgdir name="2022620">
     <string name="name" value="Handmade Sandwich "/>
@@ -8529,11 +8529,11 @@
   </imgdir>
   <imgdir name="2022621">
     <string name="name" value="Tasty Milk"/>
-    <string name="desc" value="Fresh milk produced at the farm. \nRecovers around 100 HP."/>
+    <string name="desc" value="Fresh milk produced at the farm.\nRecovers around 100 HP."/>
   </imgdir>
   <imgdir name="2022622">
     <string name="name" value="Squeezed Juice"/>
-    <string name="desc" value="Fresh juice produced at the farm. \nRecovers around 50 MP."/>
+    <string name="desc" value="Fresh juice produced at the farm.\nRecovers around 50 MP."/>
   </imgdir>
   <imgdir name="2022631">
     <string name="name" value="Rose Scent"/>
@@ -8565,7 +8565,7 @@
   </imgdir>
   <imgdir name="2000002">
     <string name="name" value="White Potion"/>
-    <string name="desc" value="A highly-concentrated potion made out of red herbs.\nRecovers 300 HP."/>
+    <string name="desc" value="A highly concentrated potion made out of red herbs.\nRecovers 300 HP."/>
   </imgdir>
   <imgdir name="2000003">
     <string name="name" value="Blue Potion"/>
@@ -8573,503 +8573,503 @@
   </imgdir>
   <imgdir name="2290000">
     <string name="name" value="[Mastery Book] Monster Magnet"/>
-    <string name="desc" value="This increases master level of the  #cMonster Magnet# skill up to 20 with 70% chance of success.\r\nJob : 4th Advancement Warrior\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of the #cMonster Magnet# skill to 20 with a 70% chance of success.\nJob: 4th Advancement Warrior\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290001">
     <string name="name" value="[Mastery Book] Monster Magnet"/>
-    <string name="desc" value="This increases master level of the  #cMonster Magnet# skill up to 30 with 50% chance of success. \r\nJob : 4th Advancement Warrior\r\nCondition : Skill Level above 15"/>
+    <string name="desc" value="This increases the master level of the #cMonster Magnet# skill to 30 with a 50% chance of success.\nJob: 4th Advancement Warrior\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290002">
     <string name="name" value="[Mastery Book] Achilles"/>
-    <string name="desc" value="This increases the master level of #cAchilles# up to 20 with 70% of chance.\r\nJob : 4th Advancement Warrior\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cAchilles# to 20 with a 70% chance of success.\nJob: 4th Advancement Warrior\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290003">
     <string name="name" value="[Mastery Book] Achilles"/>
-    <string name="desc" value="This increases the master level of #cAchilles# up to 30 with 50% of chance.\r\nJob : 4th Advancement Warrior\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cAchilles# to 30 with a 50% chance of success.\nJob: 4th Advancement Warrior\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290004">
     <string name="name" value="[Mastery Book] Rush"/>
-    <string name="desc" value="This increases the master level of #cRush# up to 20 with 70% of chance.\r\nJob : 4th Advancement Warrior\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cRush# to 20 with a 70% chance of success.\nJob: 4th Advancement Warrior\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290005">
     <string name="name" value="[Mastery Book] Rush"/>
-    <string name="desc" value="This increases the master level of #cRush# up to 30 with 50% of chance.\r\nJob : 4th Advancement Warrior\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cRush# to 30 with a 50% chance of success.\nJob: 4th Advancement Warrior\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290006">
     <string name="name" value="[Mastery Book] Power Stance"/>
-    <string name="desc" value="This increases the master level of #cPower Stance# up to 20 with 70% of chance.\r\nJob : 4th Advancement Warrior\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cPower Stance# to 20 with a 70% chance of success.\nJob: 4th Advancement Warrior\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290007">
     <string name="name" value="[Mastery Book] Power Stance"/>
-    <string name="desc" value="This increases the master level of #cPower Stance# up to 30 with 50% of chance.\r\nJob : 4th Advancement Warrior\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cPower Stance# to 30 with a 50% chance of success.\nJob: 4th Advancement Warrior\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290008">
     <string name="name" value="[Mastery Book] Advanced Combo Attack"/>
-    <string name="desc" value="This increases the master level of #cAdvanced Combo Attack# up to 20 with 70% of chance.\r\nClass : Hero\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cAdvanced Combo Attack# to 20 with a 70% chance of success.\nClass: Hero\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290009">
     <string name="name" value="[Mastery Book] Advanced Combo Attack"/>
-    <string name="desc" value="This increases the master level of #cAdvanced Combo Attack# up to 30 with 50% of chance.\r\nClass : Hero\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cAdvanced Combo Attack# to 30 with a 50% chance of success.\nClass: Hero\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290010">
     <string name="name" value="[Mastery Book] Brandish"/>
-    <string name="desc" value="This increases the master level of #cBrandish# up to 20 with 70% of chance.\r\nClass : Hero\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cBrandish# to 20 with a 70% chance of success.\nClass: Hero\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290011">
     <string name="name" value="[Mastery Book] Brandish"/>
-    <string name="desc" value="This increases the master level of #cBrandish# up to 30 with 50% of chance.\r\nClass : Hero\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cBrandish# to 30 with a 50% chance of success.\nClass: Hero\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290012">
     <string name="name" value="[Mastery Book] Blast"/>
-    <string name="desc" value="This increases the master level of #cBlast # up to 20 with 70% of chance.\r\nClass : Paladin\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cBlast # to 20 with a 70% chance of success.\nClass: Paladin\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290013">
     <string name="name" value="[Mastery Book] Blast"/>
-    <string name="desc" value="This increases the master level of #cBlast# up to 30 with 50% of chance.\r\nClass : Paladin\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cBlast# to 30 with a 50% chance of success.\nClass: Paladin\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290014">
     <string name="name" value="[Mastery Book] Guardian"/>
-    <string name="desc" value="This increases the master level of #cGuardian# up to 20 with 70% of chance.\r\nClass : Hero,Paladin\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cGuardian# to 20 with a 70% chance of success.\nClass: Hero, Paladin\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290015">
     <string name="name" value="[Mastery Book] Guardian"/>
-    <string name="desc" value="This increases the master level of #cGuardian# up to 30 with 50% of chance.\r\nClass : Hero,Paladin\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cGuardian# to 30 with a 50% chance of success.\nClass: Hero, Paladin\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290016">
     <string name="name" value="[Mastery Book] Enrage"/>
-    <string name="desc" value="This increases the master level of #cEnrage# up to 20 with 70% of chance.\r\nClass : Hero\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cEnrage# to 20 with a 70% chance of success.\nClass: Hero\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290017">
     <string name="name" value="[Mastery Book] Enrage"/>
-    <string name="desc" value="This increases the master level of #cEnrage# up to 30 with 50% of chance.\r\nClass : Hero\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cEnrage# to 30 with a 50% chance of success.\nClass: Hero\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290018">
     <string name="name" value="[Mastery Book] Holy Charge"/>
-    <string name="desc" value="This increases the master level of #cHoly Charge# up to 20 with 70% of chance.\r\nClass : Paladin\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cHoly Charge# to 20 with a 70% chance of success.\nClass: Paladin\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290019">
     <string name="name" value="[Mastery Book] Divine Charge"/>
-    <string name="desc" value="This increases the master level of #cDivine Charge# up to 20 with 70% of chance.\r\nClass : Paladin\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cDivine Charge# to 20 with a 70% chance of success.\nClass: Paladin\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290020">
     <string name="name" value="[Mastery Book] Heaven&apos;s Hammer"/>
-    <string name="desc" value="This increases the master level of #cHeaven&apos;s Hammer# up to 20 with 70% of chance.\r\nClass : Paladin\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cHeaven&apos;s Hammer# to 20 with a 70% chance of success.\nClass: Paladin\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290021">
     <string name="name" value="[Mastery Book] Heaven&apos;s Hammer"/>
-    <string name="desc" value="This increases the master level of #cHeaven&apos;s Hammer# up to 30 with 50% of chance.\r\nClass : Paladin\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cHeaven&apos;s Hammer# to 30 with a 50% chance of success.\nClass: Paladin\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290022">
     <string name="name" value="[Mastery Book] Berserk"/>
-    <string name="desc" value="This increases the master level of #cBerserk# up to 20 with 70% of chance.\r\nClass : Dark Knight\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cBerserk# to 20 with a 70% chance of success.\nClass: Dark Knight\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290023">
     <string name="name" value="[Mastery Book] Berserk"/>
-    <string name="desc" value="This increases the master level of #cBerserk# up to 30 with 50% of chance.\r\nClass : Dark Knight\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cBerserk# to 30 with a 50% chance of success.\nClass: Dark Knight\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290024">
     <string name="name" value="[Mastery Book] Mana Reflection"/>
-    <string name="desc" value="This increases the master level of #cMana Reflection# up to 20 with 70% of chance.\r\nJob : 4th Advancement Magician\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cMana Reflection# to 20 with a 70% chance of success.\nJob: 4th Advancement Magician\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290025">
     <string name="name" value="[Mastery Book] Mana Reflection"/>
-    <string name="desc" value="This increases the master level of #cMana Reflection# up to 30 with 50% of chance.\r\nJob : 4th Advancement Magician\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cMana Reflection# to 30 with a 50% chance of success.\nJob: 4th Advancement Magician\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290026">
     <string name="name" value="[Mastery Book] Big Bang"/>
-    <string name="desc" value="This increases the master level of #cBig Bang# up to 20 with 70% of chance.\r\nJob : 4th Advancement Magician\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cBig Bang# to 20 with a 70% chance of success.\nJob: 4th Advancement Magician\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290027">
     <string name="name" value="[Mastery Book] Big Bang"/>
-    <string name="desc" value="This increases the master level of #cBig Bang # up to 30 with 50% of chance.\r\nJob : 4th Advancement Magician\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cBig Bang# to 30 with a 50% chance of success.\nJob: 4th Advancement Magician\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290028">
     <string name="name" value="[Mastery Book] Infinity"/>
-    <string name="desc" value="This increases the master level of #cInfinity# up to 20 with 70% of chance.\r\nJob : 4th Advancement Magician\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cInfinity# to 20 with a 70% chance of success.\nJob: 4th Advancement Magician\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290029">
     <string name="name" value="[Mastery Book] Infinity"/>
-    <string name="desc" value="This increases the master level of #cInfinity# up to 30 with 50% of chance.\r\nJob : 4th Advancement Magician\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cInfinity# to 30 with a 50% chance of success.\nJob: 4th Advancement Magician\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290030">
     <string name="name" value="[Mastery Book] Paralyze"/>
-    <string name="desc" value="This increases the master level of #cParalyze# up to 20 with 70% of chance.\r\nClass : Arch Mage(Fire,Poison)\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cParalyze# to 20 with a 70% chance of success.\nClass: Arch Mage (Fire,Poison)\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290031">
     <string name="name" value="[Mastery Book] Paralyze"/>
-    <string name="desc" value="This increases the master level of #cParalyze# up to 30 with 50% of chance.\r\nClass : Arch Mage(Fire,Poison)\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cParalyze# to 30 with a 50% chance of success.\nClass: Arch Mage (Fire,Poison)\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290032">
     <string name="name" value="[Mastery Book] Chain Lightning"/>
-    <string name="desc" value="This increases the master level of #cChain Lightning# up to 20 with 70% of chance.\r\nClass : Arch Mage(Ice, Lightning)\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cChain Lightning# to 20 with a 70% chance of success.\nClass: Arch Mage (Ice,Lightning)\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290033">
     <string name="name" value="[Mastery Book] Chain Lightning"/>
-    <string name="desc" value="This increases the master level of #cChain Lightning# up to 30 with 50% of chance.\r\nClass : Arch Mage(Ice, Lightning)\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cChain Lightning# to 30 with a 50% chance of success.\nClass: Arch Mage (Ice,Lightning)\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290034">
     <string name="name" value="[Mastery Book]  Holy Shield"/>
-    <string name="desc" value="This increases the master level of #cHoly Shield# up to 20 with 70% of chance.\r\nClass : Bishop\r\nCondition : Skill Level above 5"/>
+    <string name="desc" value="This increases the master level of #cHoly Shield# to 20 with a 70% chance of success.\nClass: Bishop\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290035">
     <string name="name" value="[Mastery Book] Holy Shield"/>
-    <string name="desc" value="This increases the master level of #cHoly Shield# up to 30 with 50% of chance.\r\nClass : Bishop\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cHoly Shield# to 30 with a 50% chance of success.\nClass: Bishop\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290036">
     <string name="name" value="[Mastery Book] Fire Demon"/>
-    <string name="desc" value="This increases the master level of #cFire Demon# up to 20 with 70% of chance.\r\nClass : Arch Mage(Fire,Poison)\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cFire Demon# to 20 with a 70% chance of success.\nClass: Arch Mage (Fire,Poison)\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290037">
     <string name="name" value="[Mastery Book] Fire Demon"/>
-    <string name="desc" value="This increases the master level of #cFire Demon# up to 30 with 50% of chance.\r\nClass : Arch Mage(Fire,Poison)\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cFire Demon# to 30 with a 50% chance of success.\nClass: Arch Mage (Fire,Poison)\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290038">
     <string name="name" value="[Mastery Book] Elquines"/>
-    <string name="desc" value="This increases the master level of #cElquines# up to 20 with 70% of chance.\r\nClass : Arch Mage(Fire,Poison)\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cElquines# to 20 with a 70% chance of success.\nClass: Arch Mage (Fire,Poison)\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290039">
     <string name="name" value="[Mastery Book] Elquines"/>
-    <string name="desc" value="This increases the master level of #cElquines# up to 30 with 50% of chance.\r\nClass : Arch Mage(Fire,Poison)\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cElquines# to 30 with a 50% chance of success.\nClass: Arch Mage (Fire,Poison)\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290040">
     <string name="name" value="[Mastery Book] Meteor Shower"/>
-    <string name="desc" value="This increases the master level of #cMeteor Shower# up to 20 with 70% of chance.\r\nClass : Arch Mage(Fire,Poison)\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cMeteor Shower# to 20 with a 70% chance of success.\nClass: Arch Mage (Fire,Poison)\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290041">
     <string name="name" value="[Mastery Book] Meteor Shower"/>
-    <string name="desc" value="This increases the master level of #cMeteor Shower# up to 30 with 50% of chance.\r\nClass : Arch Mage(Fire,Poison)\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cMeteor Shower# to 30 with a 50% chance of success.\nClass: Arch Mage (Fire,Poison)\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290042">
     <string name="name" value="[Mastery Book] Ice Demon"/>
-    <string name="desc" value="This increases the master level of #cIce Demon# up to 20 with 70% of chance.\r\nClass : Arch Mage(Ice, Lightning)\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cIce Demon# to 20 with a 70% chance of success.\nClass: Arch Mage (Ice,Lightning)\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290043">
     <string name="name" value="[Mastery Book] Ice Demon"/>
-    <string name="desc" value="This increases the master level of #cIce Demon# up to 30 with 50% of chance.\r\nClass : Arch Mage(Ice, Lightning)\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cIce Demon# to 30 with a 50% chance of success.\nClass: Arch Mage (Ice,Lightning)\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290044">
     <string name="name" value="[Mastery Book] Ifrit"/>
-    <string name="desc" value="This increases the master level of #cIfrit# up to 20 with 70% of chance.\r\nClass : Arch Mage(Ice,Lightning)\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cIfrit# to 20 with a 70% chance of success.\nClass: Arch Mage (Ice,Lightning)\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290045">
     <string name="name" value="[Mastery Book] Ifrit"/>
-    <string name="desc" value="This increases the master level of #cIfrit# up to 30 with 50% of chance.\r\nClass : Arch Mage(Ice,Lightning)\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cIfrit# to 30 with a 50% chance of success.\nClass: Arch Mage (Ice,Lightning)\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290046">
     <string name="name" value="[Mastery Book] Blizzard"/>
-    <string name="desc" value="This increases the master level of #cBlizzard# up to 20 with 70% of chance.\r\nClass : Arch Mage(Ice,Lightning)\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cBlizzard# to 20 with a 70% chance of success.\nClass: Arch Mage (Ice,Lightning)\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290047">
     <string name="name" value="[Mastery Book] Blizzard"/>
-    <string name="desc" value="This increases the master level of #cBlizzard# up to 30 with 50% of chance.\r\nClass : Arch Mage(Ice,Lightning)\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cBlizzard# to 30 with a 50% chance of success.\nClass: Arch Mage (Ice,Lightning)\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290048">
     <string name="name" value="[Mastery Book] Genesis"/>
-    <string name="desc" value="This increases the master level of #cGenesis# up to 20 with 70% of chance.\r\nClass : Bishop\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cGenesis# to 20 with a 70% chance of success.\nClass: Bishop\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290049">
     <string name="name" value="[Mastery Book] Genesis"/>
-    <string name="desc" value="This increases the master level of #cGenesis# up to 30 with 50% of chance.\r\nClass : Bishop\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cGenesis# to 30 with a 50% chance of success.\nClass: Bishop\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290050">
     <string name="name" value="[Mastery Book] Angel Ray"/>
-    <string name="desc" value="This increases the master level of #cAngel Ray# up to 20 with 70% of chance.\r\nClass : Bishop\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cAngel Ray# to 20 with a 70% chance of success.\nClass: Bishop\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290051">
     <string name="name" value="[Mastery Book] Angel Ray"/>
-    <string name="desc" value="This increases the master level of #cAngel Ray# up to 30 with 50% of chance.\r\nClass : Bishop\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cAngel Ray# to 30 with a 50% chance of success.\nClass: Bishop\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290052">
     <string name="name" value="[Mastery Book] Sharp Eyes"/>
-    <string name="desc" value="This increases the master level of #cSharp Eyes# up to 20 with 70% of chance.\r\nJob : 4th Advancement Bowman\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cSharp Eyes# to 20 with a 70% chance of success.\nJob: 4th Advancement Bowman\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290053">
     <string name="name" value="[Mastery Book] Sharp Eyes"/>
-    <string name="desc" value="This increases the master level of #cSharp Eyes# up to 30 with 50% of chance.\r\nJob : 4th Advancement Bowman\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cSharp Eyes# to 30 with a 50% chance of success.\nJob: 4th Advancement Bowman\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290054">
     <string name="name" value="[Mastery Book] Dragon&apos;s Breath"/>
-    <string name="desc" value="This increases the master level of #cDragon&apos;s Breath# up to 20 with 70% of chance.\r\nJob : 4th Advancement Bowman\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cDragon&apos;s Breath# to 20 with a 70% chance of success.\nJob: 4th Advancement Bowman\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290055">
     <string name="name" value="[Mastery Book] Dragon&apos;s Breath"/>
-    <string name="desc" value="This increases the master level of #cDragon&apos;s Breath# up to 30 with 50% of chance.\r\nJob : 4th Advancement Bowman\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cDragon&apos;s Breath# to 30 with a 50% chance of success.\nJob: 4th Advancement Bowman\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290056">
     <string name="name" value="[Mastery Book] Bow Expert"/>
-    <string name="desc" value="This increases the master level of #cBow Expert# up to 20 with 70% of chance.\r\nClass : Bow Master\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cBow Expert# to 20 with a 70% chance of success.\nClass: Bow Master\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290057">
     <string name="name" value="[Mastery Book] Bow Expert"/>
-    <string name="desc" value="This increases the master level of #cBow Expert # up to 30 with 50% of chance.\r\nClass : Bow Master\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cBow Expert# to 30 with a 50% chance of success.\nClass: Bow Master\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290058">
     <string name="name" value="[Mastery Book] Hamstring Shot"/>
-    <string name="desc" value="This increases the master level of #cHamstring Shot# up to 20 with 70% of chance.\r\nClass : Bow Master\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cHamstring Shot# to 20 with a 70% chance of success.\nClass: Bow Master\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290059">
     <string name="name" value="[Mastery Book] Hamstring Shot"/>
-    <string name="desc" value="This increases the master level of #cHamstring Shot# up to 30 with 50% of chance.\r\nClass : Bow Master\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cHamstring Shot# to 30 with a 50% chance of success.\nClass: Bow Master\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290060">
     <string name="name" value="[Mastery Book] Hurricane"/>
-    <string name="desc" value="This increases the master level of #cHurricane# up to 20 with 70% of chance.\r\nClass : Bow Master\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cHurricane# to 20 with a 70% chance of success.\nClass: Bow Master\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290061">
     <string name="name" value="[Mastery Book] Hurricane"/>
-    <string name="desc" value="This increases the master level of #cHurricane# up to 30 with 50% of chance.\r\nClass : Bow Master\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cHurricane# to 30 with a 50% chance of success.\nClass: Bow Master\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290062">
     <string name="name" value="[Mastery Book] Phoenix"/>
-    <string name="desc" value="This increases the master level of #cPhoenix# up to 20 with 70% of chance.\r\nClass : Bow Master\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cPhoenix# to 20 with a 70% chance of success.\nClass: Bow Master\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290063">
     <string name="name" value="[Mastery Book] Phoenix"/>
-    <string name="desc" value="This increases the master level of #cPhoenix# up to 30 with 50% of chance.\r\nClass : Bow Master\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cPhoenix# to 30 with a 50% chance of success.\nClass: Bow Master\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290064">
     <string name="name" value="[Mastery Book] Concentrate"/>
-    <string name="desc" value="This increases the master level of #cConcentrate# up to 20 with 70% of chance.\r\nClass : Bow Master\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cConcentrate# to 20 with a 70% chance of success.\nClass: Bow Master\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290065">
     <string name="name" value="[Mastery Book] Concentrate"/>
-    <string name="desc" value="This increases the master level of #cConcentrate# up to 30 with 50% of chance.\r\nClass : Bow Master\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cConcentrate# to 30 with a 50% chance of success.\nClass: Bow Master\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290066">
     <string name="name" value="[Mastery Book] Marksman Boost"/>
-    <string name="desc" value="This increases the master level of #cMarksman Boost# up to 20 with 70% of chance.\r\nClass : Marksman\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cMarksman Boost# to 20 with a 70% chance of success.\nClass: Marksman\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290067">
     <string name="name" value="[Mastery Book] Marksman Boost"/>
-    <string name="desc" value="This increases the master level of #cMarksman Boost# up to 30 with 50% of chance.\r\nClass : Marksman\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cMarksman Boost# to 30 with a 50% chance of success.\nClass: Marksman\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290068">
     <string name="name" value="[Mastery Book] Blind"/>
-    <string name="desc" value="This increases the master level of #cBlind# up to 20 with 70% of chance.\r\nClass : Marksman\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cBlind# to 20 with a 70% chance of success.\nClass: Marksman\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290069">
     <string name="name" value="[Mastery Book] Blind"/>
-    <string name="desc" value="This increases the master level of #cBlind# up to 30 with 50% of chance.\r\nClass : Marksman\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cBlind# to 30 with a 50% chance of success.\nClass: Marksman\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290070">
     <string name="name" value="[Mastery Book] Piercing Arrow"/>
-    <string name="desc" value="This increases the master level of #cPiercing Arrow# up to 20 with 70% of chance.\r\nClass : Marksman\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cPiercing Arrow# to 20 with a 70% chance of success.\nClass: Marksman\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290071">
     <string name="name" value="[Mastery Book] Piercing Arrow"/>
-    <string name="desc" value="This increases the master level of #cPiercing Arrow# up to 30 with 50% of chance. \r\nClass : Marksman\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cPiercing Arrow# to 30 with a 50% chance of success.\nClass: Marksman\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290072">
     <string name="name" value="[Mastery Book] Frostprey"/>
-    <string name="desc" value="This increases the master level of #cFrostprey# up to 20 with 70% of chance.\r\nClass : Marksman\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cFrostprey# to 20 with a 70% chance of success.\nClass: Marksman\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290073">
     <string name="name" value="[Mastery Book] Frostprey"/>
-    <string name="desc" value="This increases the master level of #cFrostprey# up to 30 with 50% of chance.\r\nClass : Marksman\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cFrostprey# to 30 with a 50% chance of success.\nClass: Marksman\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290074">
     <string name="name" value="[Mastery Book] Snipe"/>
-    <string name="desc" value="This increases the master level of #cSnipe# up to 20 with 70% of chance.\r\nClass : Marksman\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cSnipe# to 20 with a 70% chance of success.\nClass: Marksman\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290075">
     <string name="name" value="[Mastery Book] Snipe"/>
-    <string name="desc" value="This increases the master level of #cSnipe# up to 30 with 50% of chance.\r\nClass : Marksman\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cSnipe# to 30 with a 50% chance of success.\nClass: Marksman\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290076">
     <string name="name" value="[Mastery Book] Shadow Shifter"/>
-    <string name="desc" value="This increases the master level of #cShadow Shifter# up to 20 with 70% of chance.\r\nJob : 4th Advancement Thief\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cShadow Shifter# to 20 with a 70% chance of success.\nJob: 4th Advancement Thief\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290077">
     <string name="name" value="[Mastery Book] Shadow Shifter"/>
-    <string name="desc" value="This increases the master level of #cShadow Shifter# up to 30 with 50% of chance.\r\nJob : 4th Advancement Thief\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cShadow Shifter# to 30 with a 50% chance of success.\nJob: 4th Advancement Thief\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290078">
     <string name="name" value="[Mastery Book] Venomous Star/Venomous Stab"/>
-    <string name="desc" value="This increases the master level of #cVenomous Star or Venomous Stab# up to 20 with 70% of chance.\r\nJob : 4th Advancement Thief\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cVenomous Star or Venomous Stab# to 20 with a 70% chance of success.\nJob: 4th Advancement Thief\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290079">
     <string name="name" value="[Mastery Book] Venomous Star/Venomous Stab"/>
-    <string name="desc" value="This increases the master level of #cVenomous Star or Venomous Stab# up to 30 with 50% of chance. \r\nJob : 4th Advancement Thief\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cVenomous Star or Venomous Stab# to 30 with a 50% chance of success.\nJob: 4th Advancement Thief\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290080">
     <string name="name" value="[Mastery Book] Taunt"/>
-    <string name="desc" value="This increases the master level of #cTaunt# up to 20 with 70% of chance.\r\nJob : 4th Advancement Thief\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cTaunt# to 20 with a 70% chance of success.\nJob: 4th Advancement Thief\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290081">
     <string name="name" value="[Mastery Book] Taunt"/>
-    <string name="desc" value="This increases the master level of #cTaunt# up to 30 with 50% of chance.\r\nJob : 4th Advancement Thief\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cTaunt# to 30 with a 50% chance of success.\nJob: 4th Advancement Thief\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290082">
     <string name="name" value="[Mastery Book] Ninja Ambush"/>
-    <string name="desc" value="This increases the master level of #cNinja Ambush# up to 20 with 70% of chance.\r\nJob : 4th Advancement Thief\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cNinja Ambush# to 20 with a 70% chance of success.\nJob: 4th Advancement Thief\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290083">
     <string name="name" value="[Mastery Book] Ninja Ambush"/>
-    <string name="desc" value="This increases the master level of #cNinja Ambush# up to 30 with 50% of chance.\r\nJob : 4th Advancement Thief\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cNinja Ambush# to 30 with a 50% chance of success.\nJob: 4th Advancement Thief\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290084">
     <string name="name" value="[Mastery Book] Triple Throw"/>
-    <string name="desc" value="This increases the master level of #cTriple Throw# up to 20 with 70% of chance.\r\nClass : Night Lord\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cTriple Throw# to 20 with a 70% chance of success.\nClass: Night Lord\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290085">
     <string name="name" value="[Mastery Book] Triple Throw"/>
-    <string name="desc" value="This increases the master level of #cTriple Throw# up to 30 with 50% of chance.\r\nClass : Night Lord\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cTriple Throw# to 30 with a 50% chance of success.\nClass: Night Lord\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290086">
     <string name="name" value="[Mastery Book] Ninja Storm"/>
-    <string name="desc" value="This increases the master level of #cNinja Storm# up to 20 with 70% of chance.\r\nClass : Night Lord\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cNinja Storm# to 20 with a 70% chance of success.\nClass: Night Lord\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290087">
     <string name="name" value="[Mastery Book] Ninja Storm"/>
-    <string name="desc" value="This increases the master level of #cNinja Storm# up to 30 with 50% of chance.\r\nClass : Night Lord\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cNinja Storm# to 30 with a 50% chance of success.\nClass: Night Lord\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290088">
     <string name="name" value="[Mastery Book] Shadow Claw"/>
-    <string name="desc" value="This increases the master level of #cShadow Claw# up to 20 with 70% of chance.\r\nClass : Night Lord\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cShadow Claw# to 20 with a 70% chance of success.\nClass: Night Lord\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290089">
     <string name="name" value="[Mastery Book] Shadow Claw"/>
-    <string name="desc" value="This increases the master level of #cShadow Claw# up to 30 with 50% of chance.\r\nClass : Night Lord\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cShadow Claw# to 30 with a 50% chance of success.\nClass: Night Lord\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290090">
     <string name="name" value="[Mastery Book] Boomerang Step"/>
-    <string name="desc" value="This increases the master level of #cBoomerang Step# up to 20 with 70% of chance.\r\nClass : Shadower\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cBoomerang Step# to 20 with a 70% chance of success.\nClass: Shadower\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290091">
     <string name="name" value="[Mastery Book] Boomerang Step"/>
-    <string name="desc" value="This increases the master level of #cBoomerang Step# up to 30 with 50% of chance.\r\nClass : Shadower\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cBoomerang Step# to 30 with a 50% chance of success.\nClass: Shadower\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290092">
     <string name="name" value="[Mastery Book] Assassinate"/>
-    <string name="desc" value="This increases the master level of #cAssassinate# up to 20 with 70% of chance.\r\nClass : Shadower\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cAssassinate# to 20 with a 70% chance of success.\nClass: Shadower\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290093">
     <string name="name" value="[Mastery Book] Assassinate"/>
-    <string name="desc" value="This increases the master level of #cAssassinate# up to 30 with 50% of chance.\r\nClass : Shadower\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cAssassinate# to 30 with a 50% chance of success.\nClass: Shadower\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290094">
     <string name="name" value="[Mastery Book] Smokescreen"/>
-    <string name="desc" value="This increases the master level of #cSmokescreen# up to 20 with 70% of chance.\r\nClass : Shadower\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cSmokescreen# to 20 with a 70% chance of success.\nClass: Shadower\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290095">
     <string name="name" value="[Mastery Book] Smokescreen"/>
-    <string name="desc" value="This increases the master level of #cSmokescreen# up to 30 with 50% of chance.\r\nClass : Shadower\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cSmokescreen# to 30 with a 50% chance of success.\nClass: Shadower\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290096">
     <string name="name" value="[Mastery Book] Maple Warrior"/>
-    <string name="desc" value="This increases the master level of #cMaple Warrior# up to 20 with 70% of chance.\r\nJob : All 4th Advancement Jobs\r\nCondition : Skill level above 5"/>
+    <string name="desc" value="This increases the master level of #cMaple Warrior# to 20 with a 70% chance of success.\nJob: All 4th Advancement Jobs\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290097">
     <string name="name" value="[Mastery Book] Dragon Strike"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cDragon Strike# to 20.nJob : Buccaneer\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cDragon Strike# to 20 with a 70% chance of success.\nJob: Buccaneer\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290098">
     <string name="name" value="[Mastery Book] Dragon Strike"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cDragon Strike# to 30.nJob : Buccaneer\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cDragon Strike# to 30 with a 50% chance of success.\nJob: Buccaneer\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290099">
     <string name="name" value="[Mastery Book] Energy Orb"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cEnergy Orb# to 20.nJob : Buccaneer\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cEnergy Orb# to 20 with a 70% chance of success.\nJob: Buccaneer\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290100">
     <string name="name" value="[Mastery Book] Energy Orb"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cEnergy Orb# to 30.nJob : Buccaneer\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cEnergy Orb# to 30 with a 50% chance of success.\nJob: Buccaneer\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290101">
     <string name="name" value="[Mastery Book] Super Transformation"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cSuper Transformation# to 20.nJob : Buccaneer\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cSuper Transformation# to 20 with a 70% chance of success.\nJob: Buccaneer\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290102">
     <string name="name" value="[Mastery Book] Demolition"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cDemolition# to 20.nJob : Buccaneer\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cDemolition# to 20 with a 70% chance of success.\nJob: Buccaneer\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290103">
     <string name="name" value="[Mastery Book] Demolition"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cDemolition# to 30.nJob : Buccaneer\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cDemolition# to 30 with a 50% chance of success.\nJob: Buccaneer\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290104">
     <string name="name" value="[Mastery Book] Snatch"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cSnatch# to 20.nJob : Buccaneer\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cSnatch# to 20 with a 70% chance of success.\nJob: Buccaneer\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290105">
     <string name="name" value="[Mastery Book] Snatch"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cSnatch# to 30.nJob : Buccaneer\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cSnatch# to 30 with a 50% chance of success.\nJob: Buccaneer\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290106">
     <string name="name" value="[Mastery Book] Barrage"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cBarrage# to 20.nJob : Buccaneer\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cBarrage# to 20 with a 70% chance of success.\nJob: Buccaneer\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290107">
     <string name="name" value="[Mastery Book] Barrage"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cBarrage# to 30.nJob : Buccaneer\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cBarrage# to 30 with a 50% chance of success.\nJob: Buccaneer\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290108">
     <string name="name" value="[Mastery Book] Speed Infusion"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cSpeed Infusion# to 20.nJob : Buccaneer\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cSpeed Infusion# to 20 with a 70% chance of success.\nJob: Buccaneer\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290110">
     <string name="name" value="[Mastery Book] Time Leap"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cTime Leap# to 20.nJob : Buccaneer\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cTime Leap# to 20 with a 70% chance of success.\nJob: Buccaneer\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290111">
     <string name="name" value="[Mastery Book] Time Leap"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cTime Leap# to 30.nJob : Buccaneer\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cTime Leap# to 30 with a 50% chance of success.\nJob: Buccaneer\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290112">
     <string name="name" value="[Mastery Book] Elemental Boost"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cElemental Boost# to 20.nJob : Corsair\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cElemental Boost# to 20 with a 70% chance of success.\nJob: Corsair\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290113">
     <string name="name" value="[Mastery Book] Elemental Boost"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cElemental Boost# to 30.nJob : Corsair\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cElemental Boost# to 30 with a 50% chance of success.\nJob: Corsair\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290114">
     <string name="name" value="[Mastery Book] Wrath of the Octopi"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cWrath of the Octopi# to 20.nJob : Corsair\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cWrath of the Octopi# to 20 with a 70% chance of success.\nJob: Corsair\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290115">
     <string name="name" value="[Mastery Book] Air Strike"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cAir Strike# to 20.nJob : Corsair\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cAir Strike# to 20 with a 70% chance of success.\nJob: Corsair\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290116">
     <string name="name" value="[Mastery Book] Air Strike"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cAir Strike# to 30.nJob : Corsair\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cAir Strike# to 30 with a 50% chance of success.\nJob: Corsair\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290117">
     <string name="name" value="[Mastery Book] Rapid Fire"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cRapid Fire# to 20.\nJob : Corsairr\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cRapid Fire# to 20 with a 70% chance of success.\nJob: Corsair\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290118">
     <string name="name" value="[Mastery Book] Rapid Fire"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cRapid Fire# to 30.nJob : Corsair\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cRapid Fire# to 30 with a 50% chance of success.\nJob: Corsair\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290119">
     <string name="name" value="[Mastery Book] Battleship Cannon"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cBattleship Cannon# to 20.nJob : Corsair\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cBattleship Cannon# to 20 with a 70% chance of success.\nJob: Corsair\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290120">
     <string name="name" value="[Mastery Book] Battleship Cannon"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cBattleship Cannon# to 30.nJob : Corsair\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cBattleship Cannon# to 30 with a 50% chance of success.\nJob: Corsair\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290121">
     <string name="name" value="[Mastery Book] Battleship Torpedo"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cBattleship Torpedo# to 20.nJob : Corsair\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cBattleship Torpedo# to 20 with a 70% chance of success.\nJob: Corsair\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290122">
     <string name="name" value="[Mastery Book] Battleship Torpedo"/>
-    <string name="desc" value="With a 50% success rate, it raises the Master Level of #cBattleship Torpedo# to 30.nJob : Corsair\r\nRequirement : At least Level 15 in this skill"/>
+    <string name="desc" value="This increases the master level of #cBattleship Torpedo# to 30 with a 50% chance of success.\nJob: Corsair\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2290123">
     <string name="name" value="[Mastery Book] Hypnotize"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cHypnotize# to 20.nJob : Corsair\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cHypnotize# to 20 with a 70% chance of success.\nJob: Corsair\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290124">
     <string name="name" value="[Mastery Book] Bullseye"/>
-    <string name="desc" value="With a 70% success rate, it raises the Master Level of #cBullseye# to 20.nJob : Corsair\r\nRequirement : At least Level 5 in this skill"/>
+    <string name="desc" value="This increases the master level of #cBullseye# to 20 with a 70% chance of success.\nJob: Corsair\nCondition: At least level 5 in this skill"/>
   </imgdir>
   <imgdir name="2290125">
     <string name="name" value="[Mastery Book] Maple Warrior"/>
-    <string name="desc" value="This increases the master level of #cMaple Warrior# up to 30 with 50% of chance.\r\nJob : All 4th Advancement Jobs\r\nCondition : Skill level above 15"/>
+    <string name="desc" value="This increases the master level of #cMaple Warrior# to 30 with a 50% chance of success.\nJob: All 4th Advancement Jobs\nCondition: At least level 15 in this skill"/>
   </imgdir>
   <imgdir name="2022303">
     <string name="name" value="MISSING NAME"/>

--- a/wz/String.wz/Etc.img.xml
+++ b/wz/String.wz/Etc.img.xml
@@ -1630,7 +1630,7 @@
     </imgdir>
     <imgdir name="4001000">
       <string name="name" value="Arwen&apos;s Glass Shoes"/>
-      <string name="desc" value="A shiny glass shoes for women-only."/>
+      <string name="desc" value="A shiny glass shoes for women only."/>
     </imgdir>
     <imgdir name="4001001">
       <string name="name" value="VIP Mirror"/>
@@ -2178,7 +2178,7 @@
     </imgdir>
     <imgdir name="4001141">
       <string name="name" value="Snowman Branch"/>
-      <string name="desc" value="A tree branch used to make a Kid Snowman arm. Represents a pure innocense of the kids that made the Snowman."/>
+      <string name="desc" value="A tree branch used to make a Kid Snowman arm. Represents a pure innocence of the kids that made the Snowman."/>
     </imgdir>
     <imgdir name="4001147">
       <string name="name" value="Call of The Nautilus"/>
@@ -2366,7 +2366,7 @@
     </imgdir>
     <imgdir name="4010007">
       <string name="name" value="Lidium Ore"/>
-      <string name="desc" value="Lidium Ore that in formed under the sand."/>
+      <string name="desc" value="The ore of lidium that has formed in the sand."/>
     </imgdir>
     <imgdir name="4011000">
       <string name="name" value="Bronze Plate"/>
@@ -2430,15 +2430,15 @@
     </imgdir>
     <imgdir name="4020006">
       <string name="name" value="Topaz Ore"/>
-      <string name="desc" value="The ore of a yellow jewel"/>
+      <string name="desc" value="The ore of a yellow jewel."/>
     </imgdir>
     <imgdir name="4020007">
       <string name="name" value="Diamond Ore"/>
-      <string name="desc" value="The ore of a jewel that&apos;s transparent"/>
+      <string name="desc" value="The ore of a jewel that&apos;s transparent."/>
     </imgdir>
     <imgdir name="4020008">
       <string name="name" value="Black Crystal Ore"/>
-      <string name="desc" value="An ore of a crystal that has dark powers stored in it"/>
+      <string name="desc" value="An ore of a crystal that has dark powers stored in it."/>
     </imgdir>
     <imgdir name="4021000">
       <string name="name" value="Garnet"/>
@@ -4930,19 +4930,19 @@
     </imgdir>
     <imgdir name="4031703">
       <string name="name" value="Regular Tree Branch"/>
-      <string name="desc" value="A regular looking tree branch.  It doesn&apos;t seem to have any special powers."/>
+      <string name="desc" value="A regular looking tree branch. It doesn&apos;t seem to have any special powers."/>
     </imgdir>
     <imgdir name="4031704">
       <string name="name" value="Anonymous Research Report"/>
-      <string name="desc" value="A research report that an unknown person compiled.  The research seems to be about using metal to strengthen your body."/>
+      <string name="desc" value="A research report that an unknown person compiled. The research seems to be about using metal to strengthen your body."/>
     </imgdir>
     <imgdir name="4031705">
       <string name="name" value="Strange Bottle of Water"/>
-      <string name="desc" value="A water bottle containing transparent water.  It is tightly locked."/>
+      <string name="desc" value="A water bottle containing transparent water. It is tightly locked."/>
     </imgdir>
     <imgdir name="4031706">
       <string name="name" value="Phyllia&apos;s Letter"/>
-      <string name="desc" value="A letter Phyllia wrote to Erikson.  It seems to be about Kini&apos;s condition."/>
+      <string name="desc" value="A letter Phyllia wrote to Ericsson. It seems to be about Keeny&apos;s condition."/>
     </imgdir>
     <imgdir name="4031707">
       <string name="name" value="Ericsson&apos;s Letter"/>
@@ -4950,11 +4950,11 @@
     </imgdir>
     <imgdir name="4031708">
       <string name="name" value="Secret Document"/>
-      <string name="desc" value="A secretive document written with codes.  The bottom part is badly damaged and not readable."/>
+      <string name="desc" value="A secretive document written with codes. The bottom part is badly damaged and not readable."/>
     </imgdir>
     <imgdir name="4031709">
       <string name="name" value="Lightless Magic Device"/>
-      <string name="desc" value="A magic device that has been completely used up.  There is no more use for it."/>
+      <string name="desc" value="A magic device that has been completely used up. There is no more use for it."/>
     </imgdir>
     <imgdir name="4031710">
       <string name="name" value="Subway Ticket to NLC (Basic)"/>
@@ -7156,7 +7156,7 @@
     </imgdir>
     <imgdir name="4001175">
       <string name="name" value="Kid Shoes"/>
-      <string name="desc" value="Adorable cute shoes that are obviously only for dids."/>
+      <string name="desc" value="Adorable cute shoes that are obviously only for kids."/>
     </imgdir>
     <imgdir name="4001187">
       <string name="name" value="Beltin"/>


### PR DESCRIPTION
- Fixes for broken line returns, typos, grammar, etc.
- Tweaked various item descriptions for consistency.
- Tweaked various item descriptions to make them more GMS-like.
- Added description of item effects in tooltips for Heartstopper and Smore.
- Changed description of Sunrise Dew to indicate 4050 MP recovery (was 4000).
- Various minor edits to text relating to quests and dialogue.