### PR TITLE
Add docker-compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 # Docker support, thanks to xinyifly
 
-FROM openjdk:7-alpine
+FROM openjdk:8u171-jdk-alpine
 RUN apk -U add tini
 WORKDIR /mnt
 COPY ./ ./
 RUN sh ./posix-compile.sh
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.6.0/wait /wait
+RUN chmod +x /wait
+
 EXPOSE 8484 7575 7576 7577
-CMD exec tini -- sh ./posix-launch.sh
+ENTRYPOINT ["tini", "--"]
+CMD /wait && sh ./posix-launch.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  maplestory:
+    network_mode: "host"
+    build: .
+    depends_on:
+      - db
+    environment:
+      WAIT_HOSTS: localhost:3306
+    
+  db:
+    network_mode: "host"
+    image: mysql:5.6
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: "heavenms"
+      MYSQL_USER: "root"
+      MYSQL_PASSWORD: ""
+    volumes:
+      - ./sql:/docker-entrypoint-initdb.d


### PR DESCRIPTION
What this PR has done:

- Update Dockerfile
    - Upgrade the version of the openjdk image to 1.8.
    - Add an add-on for waiting db service available.
- Add docker-compose.yml
    - Make the services (server and db) run as normal process that using the ports (3306, 8484, 7575 .etc) on host directly.
    - The service of server would start after the db is ready.

Why:

In order to host HeavenMS in any environment with docker and docker-compose by executing only one single command.
``` sh
$ docker-compose up
```

If source code or config is changed, you would have to re-build the image and re-create a container of it.